### PR TITLE
#35 feat: Create a reusable vertical list

### DIFF
--- a/libs/features/components/ui-lists/.eslintrc.json
+++ b/libs/features/components/ui-lists/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaGroup",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-group",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/components/ui-lists/README.md
+++ b/libs/features/components/ui-lists/README.md
@@ -1,0 +1,7 @@
+# features-components-ui-lists
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test features-components-ui-lists` to execute the unit tests.

--- a/libs/features/components/ui-lists/jest.config.ts
+++ b/libs/features/components/ui-lists/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'features-components-ui-lists',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../../coverage/libs/features/components/ui-lists',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/features/components/ui-lists/project.json
+++ b/libs/features/components/ui-lists/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "features-components-ui-lists",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/features/components/ui-lists/src",
+  "prefix": "elewa-group",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/features/components/ui-lists/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/features/components/ui-lists/**/*.ts",
+          "libs/features/components/ui-lists/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/features/components/ui-lists/src/index.ts
+++ b/libs/features/components/ui-lists/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/features-components-ui-lists.module';

--- a/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.html
@@ -1,0 +1,1 @@
+<p>elewa-group-vertical-list-one works!</p>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.html
@@ -1,1 +1,7 @@
-<p>elewa-group-vertical-list-one works!</p>
+<ul class="vertical-list">
+  <li class="list-item" *ngFor="let item of items">
+    <h3 class="item-title">{{ item.title }}</h3>
+    <p class="item-description">{{ item.description }}</p>
+    <span class="item-date">{{ item.date }}</span>
+  </li>
+</ul>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.scss
@@ -1,0 +1,34 @@
+.vertical-list {
+    list-style: none;
+    margin: 0 2rem 0 2rem;
+}
+
+.list-item {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: solid gray 2px ;
+    padding: 1rem 0 1rem 0;
+}
+
+.item-title {
+    font-family: var(--elewa-group-website-dmsans-bold);
+    font-weight: var(--elewa-group-website-font-weight-title);
+    font-size: var(--elewa-group-website-font-size-title);
+}
+
+.item-description {
+    display: inline-block;
+    color: gray;
+    font-family: var(--elewa-group-website-dmsans-medium);
+    font-weight: var(--elewa-group-website-font-weight-subtitle);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 50ch;
+    white-space: nowrap;
+}
+
+.item-date {
+    font-family: var(--elewa-group-website-dmsans-bold);
+}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.spec.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaGroupVerticalListOneComponent } from './elewa-group-vertical-list-one.component';
+
+describe('ElewaGroupVerticalListOneComponent', () => {
+  let component: ElewaGroupVerticalListOneComponent;
+  let fixture: ComponentFixture<ElewaGroupVerticalListOneComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaGroupVerticalListOneComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaGroupVerticalListOneComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-vertical-list-one',
+  templateUrl: './elewa-group-vertical-list-one.component.html',
+  styleUrls: ['./elewa-group-vertical-list-one.component.scss'],
+})
+export class ElewaGroupVerticalListOneComponent {}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-vertical-list-one/elewa-group-vertical-list-one.component.ts
@@ -1,8 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'elewa-group-vertical-list-one',
   templateUrl: './elewa-group-vertical-list-one.component.html',
   styleUrls: ['./elewa-group-vertical-list-one.component.scss'],
 })
-export class ElewaGroupVerticalListOneComponent {}
+export class ElewaGroupVerticalListOneComponent {
+  // @Input() title = "WWF";
+  // @Input() description = "Elewa group vertical list one works!";
+  // @Input() date = "Feb 2023";
+  @Input() items = [
+    {
+      title: "WWF",
+      description: "Elewa group vertical list one works!",
+      date: "Feb 2023"
+    },
+    {
+      title: "VVOB",
+      description: "Elewa group vertical list one works!",
+      date: "Jan 2023"
+    },
+    {
+      title: "Farm",
+      description: "Elewa group vertical list one works!",
+      date: "Feb 2023"
+    }
+  ];
+}

--- a/libs/features/components/ui-lists/src/lib/features-components-ui-lists.module.ts
+++ b/libs/features/components/ui-lists/src/lib/features-components-ui-lists.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ElewaGroupVerticalListOneComponent } from './elewa-group-vertical-list-one/elewa-group-vertical-list-one.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [ElewaGroupVerticalListOneComponent],
+  exports: [ElewaGroupVerticalListOneComponent]
+})
+export class UiListsModule {}

--- a/libs/features/components/ui-lists/src/test-setup.ts
+++ b/libs/features/components/ui-lists/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/features/components/ui-lists/tsconfig.json
+++ b/libs/features/components/ui-lists/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/features/components/ui-lists/tsconfig.lib.json
+++ b/libs/features/components/ui-lists/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test-setup.ts",
+    "src/**/*.spec.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/features/components/ui-lists/tsconfig.spec.json
+++ b/libs/features/components/ui-lists/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
# Description

This pull request handles the creation of a component that enables the user to have a reusable list to display items such as projects and news among others.
Each item contains a title, a description that is limited to 50 characters and a date.

To achieve this, we needed to:

```
- Input a list item with a valid title, description and relevant date.

```

Fixes #35 - [Create a reusable vertical list for projects, news etc..](https://github.com/italanta/elewa-group/issues/35)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Screenshot

![Screenshot (356)](https://user-images.githubusercontent.com/56071589/217079679-97961127-5c55-4650-9e7f-e75ca9ad5106.png)

![Screenshot (357)](https://user-images.githubusercontent.com/56071589/217079772-6db92136-5249-40c6-9fd1-493df74a41aa.png)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration if necessary.
- [x] Pixel comparison between design page and development at runtime
- [x] Responsive to different gadgets tested using chrome developer tools (NOTE: No mobile version design provided so I implemented one I found suitable)


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
