### PR TITLE
Issue 11/ft elewa group reusable buttons

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,6 +2,7 @@
   "version": 2,
   "projects": {
     "elewa-group-website": "apps/elewa-group-website",
+    "features-components-buttons": "libs/features/components/buttons",
     "pages-elewa-about-us": "libs/pages/elewa/about-us",
     "pages-elewa-home": "libs/pages/elewa/home",
     "state-data-cms": "libs/state/data/cms",

--- a/apps/elewa-group-website/src/app/app.component.html
+++ b/apps/elewa-group-website/src/app/app.component.html
@@ -1,1 +1,2 @@
+<elewa-group-button [message]="'Learn more'" [mode]="'light'" [action]="'/home'"></elewa-group-button>
 <elewa-group-home-page></elewa-group-home-page>

--- a/apps/elewa-group-website/src/app/app.module.ts
+++ b/apps/elewa-group-website/src/app/app.module.ts
@@ -9,13 +9,16 @@ import { HomePageModule } from '@elewa-group/pages/elewa/home';
 
 import { CardsModule } from '@elewa-group/features/components/cards';
 
+import { ButtonsModule } from '@elewa-group/features/components/buttons';
+
 @NgModule({
   declarations: [AppComponent],
   imports: [
     BrowserModule, 
     ScullyLibModule,
     HomePageModule,
-    CardsModule
+    CardsModule,
+    ButtonsModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/libs/features/components/buttons/.eslintrc.json
+++ b/libs/features/components/buttons/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaGroup",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-group",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/components/buttons/README.md
+++ b/libs/features/components/buttons/README.md
@@ -1,0 +1,7 @@
+# features-components-buttons
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test features-components-buttons` to execute the unit tests.

--- a/libs/features/components/buttons/jest.config.ts
+++ b/libs/features/components/buttons/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'features-components-buttons',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../../coverage/libs/features/components/buttons',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/features/components/buttons/project.json
+++ b/libs/features/components/buttons/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "features-components-buttons",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/features/components/buttons/src",
+  "prefix": "elewa-group",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/features/components/buttons/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/features/components/buttons/**/*.ts",
+          "libs/features/components/buttons/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/features/components/buttons/src/index.ts
+++ b/libs/features/components/buttons/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/features-components-buttons.module';

--- a/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.html
+++ b/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.html
@@ -1,0 +1,1 @@
+<p>elewa-group-button works!</p>

--- a/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.html
+++ b/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.html
@@ -1,1 +1,23 @@
-<p>elewa-group-button works!</p>
+<a href="{{ action }}">
+	<button
+	  type="button"
+	  class="button"
+	  [ngStyle]="{
+		'background-color': mode === 'dark' ? '#000000' : '#FFFFFF',
+		color: mode === 'dark' ? '#FFFFFF' : '#000000'
+	  }"
+	>
+	  {{ message }}
+	  <span class="fa-stack fa-2x" id="circle">
+		<i
+		  class="fa fa-circle fa-stack-2x" id="circle"
+		  [ngClass]="mode === 'dark' ? 'light' : 'dark'"
+		></i>
+		<i
+		  class="fa fa-long-arrow-right fa-stack-1x" id="arrow"
+		  [ngClass]="mode === 'dark' ? 'dark' : 'light'"
+		  aria-hidden="true"
+		></i
+	  ></span>
+	</button>
+  </a>

--- a/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.scss
+++ b/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.scss
@@ -1,0 +1,38 @@
+.button {
+    color: var(--elewa-group-website-color-card);
+    padding: 5px 14px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    border-radius: 30px;
+    width: auto;
+    height: 45px;
+  }
+  
+  .dark {
+    color: var(--elewa-group-website-color-primary)
+  }
+  
+  .light{
+    color: var(--elewa-group-website-color-card);
+  }
+  
+  #circle{
+    height: 28px;
+    width: 28px;
+  }
+  
+  #arrow{
+    width: 24px;
+    height: 24px;
+  }
+  .button:hover #circle{
+    transform: translateX(7px);
+    transition: .5s;
+  }
+  
+  .button:hover #arrow{
+    transform: translateX(5px);
+    transition: .5s;
+  }

--- a/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.spec.ts
+++ b/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaGroupButtonComponent } from './elewa-group-button.component';
+
+describe('ElewaGroupButtonComponent', () => {
+  let component: ElewaGroupButtonComponent;
+  let fixture: ComponentFixture<ElewaGroupButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaGroupButtonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaGroupButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.ts
+++ b/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-group-button',
+  templateUrl: './elewa-group-button.component.html',
+  styleUrls: ['./elewa-group-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ElewaGroupButtonComponent {}

--- a/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.ts
+++ b/libs/features/components/buttons/src/lib/elewa-group-button/elewa-group-button.component.ts
@@ -1,9 +1,13 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
-  selector: 'elewa-group-elewa-group-button',
+  selector: 'elewa-group-button',
   templateUrl: './elewa-group-button.component.html',
   styleUrls: ['./elewa-group-button.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ElewaGroupButtonComponent {}
+export class ElewaGroupButtonComponent {
+  @Input() mode = "dark";
+  @Input() message = "hello world";
+  @Input() action: string | undefined;
+
+}

--- a/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
+++ b/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ElewaGroupButtonComponent } from './elewa-group-button/elewa-group-button.component';
+import { ElewaGroupButtonComponent } from './elewa-group-button.component';
 
 @NgModule({
   imports: [CommonModule],
   declarations: [ElewaGroupButtonComponent],
+  exports: [ElewaGroupButtonComponent ]
 })
-export class FeaturesComponentsButtonsModule {}
+
+export class ButtonsModule {}

--- a/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
+++ b/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ElewaGroupButtonComponent } from './elewa-group-button/elewa-group-button.component';
 
 @NgModule({
   imports: [CommonModule],
+  declarations: [ElewaGroupButtonComponent],
 })
 export class FeaturesComponentsButtonsModule {}

--- a/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
+++ b/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ElewaGroupButtonComponent } from './elewa-group-button.component';
+import { ElewaGroupButtonComponent } from './elewa-group-button/elewa-group-button.component';
 
 @NgModule({
   imports: [CommonModule],
   declarations: [ElewaGroupButtonComponent],
   exports: [ElewaGroupButtonComponent ]
 })
-
 export class ButtonsModule {}

--- a/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
+++ b/libs/features/components/buttons/src/lib/features-components-buttons.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class FeaturesComponentsButtonsModule {}

--- a/libs/features/components/buttons/src/test-setup.ts
+++ b/libs/features/components/buttons/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/features/components/buttons/tsconfig.json
+++ b/libs/features/components/buttons/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/features/components/buttons/tsconfig.lib.json
+++ b/libs/features/components/buttons/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test-setup.ts",
+    "src/**/*.spec.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/features/components/buttons/tsconfig.spec.json
+++ b/libs/features/components/buttons/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,9 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@elewa-group/features/components/buttons": [
+        "libs/features/components/buttons/src/index.ts"
+      ],
       "@elewa-group/pages/elewa/about-us": [
         "libs/pages/elewa/about-us/src/index.ts"
       ],


### PR DESCRIPTION
I worked on this feature with @DaisyOdongo
This pull request was to allow for a reusable button component to be used by other developers working on various features that needed it.

To achieve this, we needed to:

- Add inputs dynamically
- Integrate styling depending on modes for a good user experience
Fixes # (11) - [Example: Fixes # ([S4Y-400](https://www.w3.org/Provider/Style/dummy.html), [S4Y-100](https://www.w3.org/Provider/Style/dummy.html))](https://github.com/italanta/elewa-group/issues/11)

Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 This change requires a documentation update
Screenshot (optional)
([https://i.postimg.cc/zBy07PhM/darkmode.png])(url)
[https://i.postimg.cc/C5NBqw1V/homeroute.png](https://github.com/italanta/elewa-group/pull/url)
[https://i.postimg.cc/V6k38RCB/lightmode.png](https://github.com/italanta/elewa-group/pull/url)

How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
-When rendering the button, I changed the inputs and got the expected results, the mode changed and the button changed in appearance.
-The route entered under actions changed

Checklist:
[ heavy_check_mark] My code follows the style guidelines of this project
[ heavy_check_mark] I have performed a self-review of my code
[ heavy_check_mark] My changes generate no new warnings
