### PR TITLE
🎨 Create reusable partner orgs section #38

### DIFF
--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
@@ -1,0 +1,1 @@
+<p>elewa-group-horizontal-list-orgs works!</p>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.spec.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaGroupHorizontalListOrgsComponent } from './elewa-group-horizontal-list-orgs.component';
+
+describe('ElewaGroupHorizontalListOrgsComponent', () => {
+  let component: ElewaGroupHorizontalListOrgsComponent;
+  let fixture: ComponentFixture<ElewaGroupHorizontalListOrgsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaGroupHorizontalListOrgsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaGroupHorizontalListOrgsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-group-horizontal-list-orgs',
+  templateUrl: './elewa-group-horizontal-list-orgs.component.html',
+  styleUrls: ['./elewa-group-horizontal-list-orgs.component.scss'],
+})
+export class ElewaGroupHorizontalListOrgsComponent {}

--- a/libs/features/components/ui-lists/src/lib/features-components-ui-lists.module.ts
+++ b/libs/features/components/ui-lists/src/lib/features-components-ui-lists.module.ts
@@ -1,10 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ElewaGroupVerticalListOneComponent } from './elewa-group-vertical-list-one/elewa-group-vertical-list-one.component';
+import { ElewaGroupHorizontalListOrgsComponent } from './elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ElewaGroupVerticalListOneComponent],
-  exports: [ElewaGroupVerticalListOneComponent]
+  declarations: [
+    ElewaGroupVerticalListOneComponent,
+    ElewaGroupHorizontalListOrgsComponent,
+  ],
+  exports: [ElewaGroupVerticalListOneComponent, ElewaGroupHorizontalListOrgsComponent],
 })
 export class UiListsModule {}


### PR DESCRIPTION
# Description

This pull request is part of the work to make it easier for people to know elewa group partners. 
To achieve this, we needed to create a reusable component that shows the partners.

Fixes #38 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration if necessary.
- [x] Test A
- [x] Test B


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
