### PR TITLE
#38 :sparkles: feat: Implemented the reusable partner orgs section

### DIFF
--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
@@ -1,5 +1,5 @@
 <div class="horizontal-list-container">
     <div class="partner" *ngFor="let partner of partners">
-      <img [src]="partner.logoUrl" alt="{{ partner.name }}">
+      <img [src]="partner.logoUrl" alt="partner logo">
     </div>
 </div>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
@@ -1,1 +1,5 @@
-<p>elewa-group-horizontal-list-orgs works!</p>
+<div class="horizontal-list-container">
+    <div class="partner" *ngFor="let partner of partners">
+      <img [src]="partner.logoUrl" alt="{{ partner.name }}">
+    </div>
+</div>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.html
@@ -1,0 +1,1 @@
+<p>elewa-group-horizontal-list-orgs works!</p>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.scss
@@ -1,0 +1,17 @@
+.horizontal-list-container {
+    display: flex;
+    background-color: var(  --elewa-group-website-color);
+    justify-content: center;
+
+}
+
+.partner {
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+}
+
+img {
+    height: auto;
+    width: auto;
+}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.scss
@@ -9,9 +9,26 @@
     display: flex;
     align-items: center;
     padding: 0 10px;
+    flex-direction: row;
+    align-items: center;
 }
 
 img {
-    height: auto;
-    width: auto;
+    height: 100%;
+    width: 100%;
 }
+
+@media screen and (max-width: 767px) {
+    .horizontal-list-container {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-gap: 16px;
+    }
+
+    img {
+        height: 80%;
+        width: 80%;
+    }
+
+}
+  

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.spec.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaGroupHorizontalListOrgsComponent } from './elewa-group-horizontal-list-orgs.component';
+
+describe('ElewaGroupHorizontalListOrgsComponent', () => {
+  let component: ElewaGroupHorizontalListOrgsComponent;
+  let fixture: ComponentFixture<ElewaGroupHorizontalListOrgsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaGroupHorizontalListOrgsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaGroupHorizontalListOrgsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-group-horizontal-list-orgs',
+  templateUrl: './elewa-group-horizontal-list-orgs.component.html',
+  styleUrls: ['./elewa-group-horizontal-list-orgs.component.scss'],
+})
+export class ElewaGroupHorizontalListOrgsComponent {}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component.ts
@@ -1,8 +1,11 @@
 import { Component } from '@angular/core';
+import { partners } from '../features-components-ui-lists.partners';
 
 @Component({
   selector: 'elewa-group-elewa-group-horizontal-list-orgs',
   templateUrl: './elewa-group-horizontal-list-orgs.component.html',
   styleUrls: ['./elewa-group-horizontal-list-orgs.component.scss'],
 })
-export class ElewaGroupHorizontalListOrgsComponent {}
+export class ElewaGroupHorizontalListOrgsComponent {
+  partners = [...partners];
+}

--- a/libs/features/components/ui-lists/src/lib/features-components-ui-lists.partners.ts
+++ b/libs/features/components/ui-lists/src/lib/features-components-ui-lists.partners.ts
@@ -1,0 +1,35 @@
+export interface Partner {
+    name: string;
+    logoUrl: string;
+}
+    
+export const partners = [
+    {
+        name: 'VVOB Rwanda',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966776/vvob_logo_rlh7p9.png'
+    },
+    {
+        name: 'FarmBetter',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/farmbetter_logo_iuv0za.png'
+    },
+    {
+        name: 'Enabel',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/enabel_logo_rdbvsw.png'
+    },
+    {
+        name: 'Savics',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/savics_logo_w81jn3.png'
+    },
+    {
+        name: 'Scouts',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/scouts_logo_e10wut.png'
+    },
+    {
+        name: 'Sportlights',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/sportlights_logo_pfalfc.png'
+    },
+    {
+        name: 'WWF',
+        logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/wwf_logo_uui3oo.png'
+    }
+]

--- a/libs/features/components/ui-lists/src/lib/features-components-ui-lists.partners.ts
+++ b/libs/features/components/ui-lists/src/lib/features-components-ui-lists.partners.ts
@@ -1,35 +1,27 @@
 export interface Partner {
-    name: string;
     logoUrl: string;
 }
     
 export const partners = [
     {
-        name: 'VVOB Rwanda',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966776/vvob_logo_rlh7p9.png'
     },
     {
-        name: 'FarmBetter',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/farmbetter_logo_iuv0za.png'
     },
     {
-        name: 'Enabel',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/enabel_logo_rdbvsw.png'
     },
     {
-        name: 'Savics',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/savics_logo_w81jn3.png'
     },
     {
-        name: 'Scouts',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/scouts_logo_e10wut.png'
     },
     {
-        name: 'Sportlights',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/sportlights_logo_pfalfc.png'
     },
     {
-        name: 'WWF',
         logoUrl: 'https://res.cloudinary.com/daumrxfhi/image/upload/v1675966777/wwf_logo_uui3oo.png'
     }
 ]


### PR DESCRIPTION
# Description

This pull request is part of displaying a reusable horizontal list of partners.

To achieve this, I needed to:

1. Create a component that displays a horizontal list of partner organization logos
2. The component takes a list of imageUrls as input
Fixes # (https://github.com/italanta/elewa-group/issues/38)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
![image](https://user-images.githubusercontent.com/110067390/218052084-c4d102b2-667e-4cd6-b4fb-3f77a769460e.png)
# Mobile view
![image](https://user-images.githubusercontent.com/110067390/218487256-888130aa-a83f-4bd9-9446-cd7ce1f1a255.png)


# How Has This Been Tested?
-  Inspected using google chrome Devtools.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code