### PR TITLE
#9 feat: Create team and partners image component

### DIFF
--- a/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.html
+++ b/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.html
@@ -1,0 +1,1 @@
+<p>team-and-partners works!</p>

--- a/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.html
+++ b/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.html
@@ -1,1 +1,6 @@
-<p>team-and-partners works!</p>
+<img
+  ngSrc="{{ imageSrc }}"
+  width="{{ imgWidth }}"
+  height="{{ imgHeight }}"
+  priority
+/>

--- a/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.scss
+++ b/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.scss
@@ -1,0 +1,5 @@
+img {
+    height: auto;
+    width: 100%;
+    border-radius: 2rem;
+}

--- a/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.spec.ts
+++ b/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TeamAndPartnersComponent } from './team-and-partners.component';
+
+describe('TeamAndPartnersComponent', () => {
+  let component: TeamAndPartnersComponent;
+  let fixture: ComponentFixture<TeamAndPartnersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TeamAndPartnersComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TeamAndPartnersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.ts
+++ b/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-team-and-partners',
+  templateUrl: './team-and-partners.component.html',
+  styleUrls: ['./team-and-partners.component.scss'],
+})
+export class TeamAndPartnersComponent {}

--- a/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.ts
+++ b/libs/pages/elewa/home/src/lib/components/team-and-partners/team-and-partners.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'elewa-group-team-and-partners',
   templateUrl: './team-and-partners.component.html',
   styleUrls: ['./team-and-partners.component.scss'],
 })
-export class TeamAndPartnersComponent {}
+export class TeamAndPartnersComponent {
+  @Input() imageSrc = 'https://images.unsplash.com/photo-1506869640319-fe1a24fd76dc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80';
+  @Input() imgWidth = '340';
+  @Input() imgHeight = '200';
+}

--- a/libs/pages/elewa/home/src/lib/features-elewa-home.module.ts
+++ b/libs/pages/elewa/home/src/lib/features-elewa-home.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { LayoutModule } from '@elewa-group/elements/layout';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { HomeHeroSectionComponent } from './components/home-hero-section/home-hero-section.component';
 import { TeamAndPartnersComponent } from './components/team-and-partners/team-and-partners.component';
 
 @NgModule({
-  imports: [CommonModule, LayoutModule],
+  imports: [CommonModule, LayoutModule, NgOptimizedImage],
   declarations: [
     HomePageComponent,
     HomeHeroSectionComponent,

--- a/libs/pages/elewa/home/src/lib/features-elewa-home.module.ts
+++ b/libs/pages/elewa/home/src/lib/features-elewa-home.module.ts
@@ -1,12 +1,17 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { LayoutModule } from '@elewa-group/elements/layout';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { HomeHeroSectionComponent } from './components/home-hero-section/home-hero-section.component';
-import { LayoutModule } from '@elewa-group/elements/layout';
+import { TeamAndPartnersComponent } from './components/team-and-partners/team-and-partners.component';
 
 @NgModule({
   imports: [CommonModule, LayoutModule],
-  declarations: [HomePageComponent, HomeHeroSectionComponent],
-  exports: [HomePageComponent, HomeHeroSectionComponent],
+  declarations: [
+    HomePageComponent,
+    HomeHeroSectionComponent,
+    TeamAndPartnersComponent,
+  ],
+  exports: [HomePageComponent, HomeHeroSectionComponent,TeamAndPartnersComponent],
 })
 export class HomePageModule {}


### PR DESCRIPTION
# Description

This pull request handles the creation of a section that shows the team and partners.
It has been made responsive for a good experience on web and phone
Done in collaboration with @lilmithi

Fixes #9 Team & Partners image component

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)
![Screenshot (364)](https://user-images.githubusercontent.com/56071589/217762472-f75d1465-f536-4914-a5bd-f67ebe616b43.png)

![Screenshot (365)](https://user-images.githubusercontent.com/56071589/217762497-4438d616-139c-49a8-9407-2ef2c27c8dd5.png)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration if necessary.
- [x] Matched the rendered design to the provided mockup to compare pixels
- [x] Tested responsiveness using chrome developer tools

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
