### PR TITLE
#18 :Create About us page culture and values section

### DIFF
--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.css
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.css
@@ -1,0 +1,109 @@
+
+
+
+
+
+/* Media Queries */
+@media only screen and (max-width: 767px) {
+    #title-container {
+      width: 100%;
+      height: 7vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+  
+  
+    h1 {
+      width: 85%;
+      height: 100%;
+      font-family: var(--elewa-group-website-dmsans-bold);
+      font-size: var(--elewa-group-website-font-size-heading);
+      font-weight: var(--elewa-group-website-font-weight-title-medium);
+      color: black;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+    }
+  
+  
+    .outer-p {
+      width: 100%;
+      height: max-content;
+      font-family: var(--elewa-group-website-dmsans-medium);
+      font-size: var(--elewa-group-website-font-size-subheading);
+      display: flex;
+      flex-direction: column;
+     
+      justify-content: center;
+      align-items: flex-start;
+    }
+  
+  
+    .outer-p > p {
+      width: 85%;
+    }
+  
+  
+    .container {
+      width: 100%;
+      height: max-content;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    .container > * {
+      width: 85%;
+      height: max-content;
+      height: max-content;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+  
+  
+    .box {
+      border-top: 5px grey solid;
+      width: 100%;
+      height: 35vh;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: space-evenly;
+    }
+  
+  
+    .box > img {
+      height: 25%;
+    }
+  
+  
+    #box-last > img {
+      height: 25%;
+      margin-bottom: 4vh;
+    }
+  
+  
+    #box-last {
+      width: 100%;
+      height: 35vh;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: space-evenly;
+    }
+  
+    #box1,
+  #box3 {
+    border-right: none;
+  }
+  
+  #box2,
+  #box4 {
+    border-left: none;
+  }
+  }
+    

--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.css
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.css
@@ -1,6 +1,51 @@
 
 
 
+h2 {
+    font-size: 20px;
+    margin-left: 2vw;
+    margin-right: 2vw;
+    height: 20%;
+    font-size: var(--elewa-group-website-font-size-elewa-text);
+    font-weight: var(--elewa-group-website-font-weight-subtitle);
+  }
+  
+
+img {
+    margin-left: 2vw;
+    margin-right: 2vw;
+  }
+  
+
+p {
+    width: 80%;
+    margin-left: 2vw;
+    margin-right: 2vw;
+    height: max-content;
+    font-size: 14px;
+    text-align: justify;
+    font-family: var(--elewa-group-website-dmsans-medium);
+    font-size: var(--elewa-group-website-font-size-subheading);
+  }
+  
+  
+  .outer-p {
+    width: 30%;
+    margin-top: 10px;
+    margin-left: 8vw;
+    margin-bottom: 4vh;
+    font-family: var(--elewa-group-website-dmsans-medium);
+    font-size: var(--elewa-group-website-font-size-subheading);
+  }
+  
+  
+  h1 {
+    margin-left: 10vw;
+    font-family: var(--elewa-group-website-dmsans-bold);
+    font-size: var(--elewa-group-website-font-size-heading);
+    font-weight: var(--elewa-group-website-font-weight-title-medium);
+  }
+
 
 
 /* Media Queries */

--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.css
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.css
@@ -1,4 +1,79 @@
-
+* {
+    margin: 0;
+  }
+  
+  
+  .container {
+    margin-top: 2vw;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    height: 100vh;
+    width: 100vw;
+  }
+  
+  
+  .container-section {
+    width: 100%;
+    height: 30%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  
+  .box {
+    width: 40%;
+    height: 100%;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-evenly;
+  }
+  
+  
+  #box-last {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: none;
+    justify-content: space-evenly;
+    margin-top: 4vh;
+  }
+  
+  
+  .container-main {
+    width: 100%;
+    height: 30%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  
+  img {
+    width: 60px;
+    height: 60px;
+  }
+  
+  
+  #box1,
+  #box3 {
+    border: thin solid grey;
+    border-left: none;
+  }
+  
+  
+  #box2,
+  #box4 {
+    border: thin solid grey;
+    border-right: none;
+  }
+  
 
 
 h2 {

--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.html
@@ -1,1 +1,63 @@
-<p>elewa-culture-and-values works!</p>
+<body>
+    <div>
+        <h1>Our Culture & Values</h1>
+    </div>
+
+
+    <div class="outer-p">
+        <p>
+            Our Culture, our CODE-(T), is our light. It protects and guides us to success. It keeps our team and
+            management accountable to install, its objectives, and its long-term mission.
+        </p>
+    </div>
+
+
+    <section class="container">
+
+
+        <div class="container-section">
+            <span class="box"  id="box1">
+                <img src="https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Icons/PNG/ownership_yno4a2.png"
+                    alt="logo">
+                <h2>Cooperative </h2>
+                <p>One for all, all for one! We have a cooperative nd open mindset. If one of of us grows and does well, all should follow.</p>
+               
+            </span>
+            <span class="box" id="box2">
+                <img src="https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Icons/PNG/coorperative_kzlzrg.png"
+                    alt="logo">
+                <h2>Ownership</h2>
+                <p>We honor our commitments. We are dependable, and when things do not go as plan, as they sometimes do, we communicate early s to avoid catastrophe. </p>
+               
+            </span>
+        </div>
+
+
+        <div class="container-section">
+            <span class="box"  id="box3">
+                <img src="https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Icons/PNG/coorperative_kzlzrg.png"
+                    alt="logo">
+                <h2>Detail</h2>
+                <p>We are a Centre of Excelence as per global standards. We only compete with ourselves but find in the global standard a worthy rival we continuously challenge.</p>
+               
+            </span>
+            <span class="box" id="box4">
+                <img src="https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690300/elewa-group-website/Icons/PNG/Education_hstyzo.png"
+                    alt="logo">
+                <h2>Empathy</h2>
+                 <p> We are nothing without people, and people have different contexts and needs. Our organization  acts as a safe haven and shield for those in need.</p>
+            </span>
+        </div>
+        <div class="container-main">
+            <span class="box" id="box-last">
+                <img src="https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690300/elewa-group-website/Icons/PNG/Transparancy_fqal8q.png"
+                    alt="logo">
+                <h2>Transparency</h2>
+                <p>Transparency, an open mind, and an open heart hold our organization together. We commit to and promote full transparency to ourselves, our stakeholders, and our beneficiaries. We furthermore invest heavily in open-source and open-data projects, as true potential lies everywhere. Not just within.</p>
+            </span>
+        </div>
+    </section>
+</body>
+
+
+

--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.html
@@ -1,0 +1,1 @@
+<p>elewa-culture-and-values works!</p>

--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.spec.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaCultureAndValuesComponent } from './elewa-culture-and-values.component';
+
+describe('ElewaCultureAndValuesComponent', () => {
+  let component: ElewaCultureAndValuesComponent;
+  let fixture: ComponentFixture<ElewaCultureAndValuesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ElewaCultureAndValuesComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ElewaCultureAndValuesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/elewa-culture-and-values/elewa-culture-and-values.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-culture-and-values',
+  templateUrl: './elewa-culture-and-values.component.html',
+  styleUrls: ['./elewa-culture-and-values.component.css']
+})
+export class ElewaCultureAndValuesComponent {
+
+}

--- a/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
+++ b/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
@@ -5,10 +5,11 @@ import { TeamMembersCarouselComponent } from './components/team-members-carousel
 
 import { NextDirective } from './directives/next.directive';
 import { PrevDirective } from './directives/prev.directive';
+import { ElewaCultureAndValuesComponent } from './components/elewa-culture-and-values/elewa-culture-and-values.component';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [TeamMembersCarouselComponent, NextDirective, PrevDirective],
+  declarations: [TeamMembersCarouselComponent, NextDirective, PrevDirective, ElewaCultureAndValuesComponent],
   exports: [TeamMembersCarouselComponent]
 })
 export class AboutUsModule { }


### PR DESCRIPTION
# Description

Worked with [Danstan](https://github.com/Danstan-O)

This pull request solves issue https://github.com/italanta/elewa-group/issues/18, whereby we have created a responsive About us page culture and values section section following the design's guidelines.

Fixes https://github.com/italanta/elewa-group/issues/18

## Type of change
- [ ] New feature (non-breaking change which adds functionality)



# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation

# Screenshot (optional)

![Desktop view](https://user-images.githubusercontent.com/104866201/218558262-e20ac71c-386c-479c-92d0-c619ef868b0f.png)

![Mobile view](https://user-images.githubusercontent.com/104866201/218558428-20ed23a3-66c9-4b33-a28c-538d234c220b.png)
