### PR TITLE
#31 add banner component

### DIFF
--- a/libs/features/components/banners/src/lib/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.html
+++ b/libs/features/components/banners/src/lib/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.html
@@ -1,0 +1,9 @@
+<div [ngStyle]="{'background-color': bgColor}" class="section">
+    <div class="section-content" [ngClass]="{'image-left': placement === 'left', 'image-right': placement === 'right'}">
+      <img [src]="imageUrl" alt="section image">
+      <div class="description">
+        <h2>{{ title }}</h2>
+        <p>{{ text }}</p>
+      </div>
+    </div>
+</div>

--- a/libs/features/components/banners/src/lib/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.scss
+++ b/libs/features/components/banners/src/lib/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.scss
@@ -1,0 +1,54 @@
+
+.section {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0 0 30px 30px;
+  padding: 1rem;
+  height: 100vh;
+
+}
+.section-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 65%;
+  margin: 0 auto;
+}
+
+.image-left {
+  flex-direction: row-reverse;
+}
+
+.image-right {
+  flex-direction: row;
+}
+
+img {
+  width: 40%;
+  height: auto;
+  margin: 1rem;
+}
+
+.description {
+  width: 40%;
+  font-weight: var(--elewa-group-website-font-size-description);
+  color: var(--elewa-group-website-color-card-item3);
+  word-wrap: break-word;
+  word-break: break-word;
+}
+h1{
+  font-weight: var(--elewa-group-website-font-weight-title-medium);
+  font-size: var(--elewa-group-website-font-size-title-medium);
+  }
+  
+  @media screen and (max-width: 767px) {
+   
+    .section-content {
+      width: 100%;
+    }
+    
+    .description {
+      width: 100%;
+    }   
+  }

--- a/libs/features/components/banners/src/lib/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.ts
+++ b/libs/features/components/banners/src/lib/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.ts
@@ -1,0 +1,15 @@
+import { Component,Input } from '@angular/core';
+  
+
+@Component({
+  selector: 'elewa-group-elewa-group-image-and-text-banner',
+  templateUrl: './elewa-group-image-and-text-banner.component.html',
+  styleUrls: ['./elewa-group-image-and-text-banner.component.scss'],
+})
+export class ElewaGroupImageAndTextBannerComponent {
+  @Input() title = 'A cooperative mindset';
+  @Input() placement: 'left' | 'right' = 'left';
+  @Input() text = `Elewa's businesses have one objective to  unlock true potential of individuals, teams, and communities. All our talents are enrolled in a personal growth track. In turn, they contribute their own growth towards the growth of others, the group and their communities.`;
+  @Input() imageUrl = "https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Images/gettyimages-525701055-2048x2048_g7nbt1.png"
+  @Input() bgColor = '#D3D3D3';
+}


### PR DESCRIPTION
# Description
This is a component to display the image and text side by side either to the left or right.

To achieve this, we needed to:
- create a component in libs/features/components/banners using the following command
nx g @nrwl/angular:library feature/components/banners
- create a component with the name elewa-group-image-and-text-banner
nx g c elewa-group-image-and-text-banner

Fixes # 31
# Screenshot (optional)
![image](https://user-images.githubusercontent.com/100309346/218987227-8c10a12c-1155-45e1-a710-4f4a325a0139.png)

# Checklist:
-  My code follows the style guidelines of this project
-  I have performed a self-review of my code
-  I have made corresponding changes to the documentation
-  My changes generate no new warnings

