### PR TITLE
34 social impact open knowledge

### DIFF
--- a/libs/pages/elewa/social-impact/.eslintrc.json
+++ b/libs/pages/elewa/social-impact/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaGroup",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-group",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/pages/elewa/social-impact/README.md
+++ b/libs/pages/elewa/social-impact/README.md
@@ -1,0 +1,7 @@
+# pages-elewa-social-impact
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test pages-elewa-social-impact` to execute the unit tests.

--- a/libs/pages/elewa/social-impact/jest.config.ts
+++ b/libs/pages/elewa/social-impact/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'pages-elewa-social-impact',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../../coverage/libs/pages/elewa/social-impact',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/pages/elewa/social-impact/project.json
+++ b/libs/pages/elewa/social-impact/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "pages-elewa-social-impact",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/pages/elewa/social-impact/src",
+  "prefix": "elewa-group",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/pages/elewa/social-impact/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/pages/elewa/social-impact/**/*.ts",
+          "libs/pages/elewa/social-impact/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/pages/elewa/social-impact/src/index.ts
+++ b/libs/pages/elewa/social-impact/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/pages-elewa-social-impact.module';

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.html
@@ -1,1 +1,7 @@
-<p>social-impact-open-knowledge works!</p>
+<elewa-group-elewa-group-image-and-text-banner
+[titleText]= "titleText"
+[paragraphText]= "paragraphText"
+[imageURL]= "imageURL"
+[backgroundColor]= "backgroundColor"
+[ngStyle]= "{'color': 'white'}"
+></elewa-group-elewa-group-image-and-text-banner>

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.html
@@ -3,5 +3,5 @@
 [paragraphText]= "paragraphText"
 [imageURL]= "imageURL"
 [backgroundColor]= "backgroundColor"
-[ngStyle]= "{'color': 'white'}"
+[ngStyle]= "{'color': color}"
 ></elewa-group-elewa-group-image-and-text-banner>

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.html
@@ -1,0 +1,1 @@
+<p>social-impact-open-knowledge works!</p>

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.spec.ts
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SocialImpactOpenKnowledgeComponent } from './social-impact-open-knowledge.component';
+
+describe('SocialImpactOpenKnowledgeComponent', () => {
+  let component: SocialImpactOpenKnowledgeComponent;
+  let fixture: ComponentFixture<SocialImpactOpenKnowledgeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SocialImpactOpenKnowledgeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SocialImpactOpenKnowledgeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.ts
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.ts
@@ -5,4 +5,9 @@ import { Component } from '@angular/core';
   templateUrl: './social-impact-open-knowledge.component.html',
   styleUrls: ['./social-impact-open-knowledge.component.scss'],
 })
-export class SocialImpactOpenKnowledgeComponent {}
+export class SocialImpactOpenKnowledgeComponent {
+  titleText = "Open knowledge"
+  paragraphText = "What we learn, we share. Through community events, open knowledge repositories, regular teaching moments(everyone a teacher) and academic partnerships. We build for today, with a lens for tomorrow."
+  backgroundColor = "black"
+  imageURL = "https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690302/elewa-group-website/Images/unnamed_1_m3dvll.png"
+}

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.ts
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-social-impact-open-knowledge',
+  templateUrl: './social-impact-open-knowledge.component.html',
+  styleUrls: ['./social-impact-open-knowledge.component.scss'],
+})
+export class SocialImpactOpenKnowledgeComponent {}

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.ts
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-open-knowledge/social-impact-open-knowledge.component.ts
@@ -8,6 +8,7 @@ import { Component } from '@angular/core';
 export class SocialImpactOpenKnowledgeComponent {
   titleText = "Open knowledge"
   paragraphText = "What we learn, we share. Through community events, open knowledge repositories, regular teaching moments(everyone a teacher) and academic partnerships. We build for today, with a lens for tomorrow."
-  backgroundColor = "black"
+  backgroundColor = "var(--elewa-group-website-color-bg)"
   imageURL = "https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690302/elewa-group-website/Images/unnamed_1_m3dvll.png"
+  color = "var(--elewa-group-website-color)"
 }

--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SocialImpactOpenKnowledgeComponent } from './components/social-impact-open-knowledge/social-impact-open-knowledge.component';
+import { BannersModule } from '@elewa-group/features/components/banners';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, BannersModule],
   declarations: [SocialImpactOpenKnowledgeComponent],
+  exports: [SocialImpactOpenKnowledgeComponent]
 })
 export class PagesElewaSocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { SocialImpactOpenKnowledgeComponent } from './components/social-impact-open-knowledge/social-impact-open-knowledge.component';
 
 @NgModule({
   imports: [CommonModule],
+  declarations: [SocialImpactOpenKnowledgeComponent],
 })
 export class PagesElewaSocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class PagesElewaSocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/test-setup.ts
+++ b/libs/pages/elewa/social-impact/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/pages/elewa/social-impact/tsconfig.json
+++ b/libs/pages/elewa/social-impact/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/pages/elewa/social-impact/tsconfig.lib.json
+++ b/libs/pages/elewa/social-impact/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test-setup.ts",
+    "src/**/*.spec.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/pages/elewa/social-impact/tsconfig.spec.json
+++ b/libs/pages/elewa/social-impact/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
# Description

Created a section that describes the organisation open knowledge that shows an image on the right side, a paragraph of text and a title. This component displays provided text and images side by side on the social impact section using the reusable component in issue #31.

To achieve this, we needed to:
- Step 1: Created social-impact library inside the pages directory using:
```
nx g @nrwl/angular:library pages/elewa/social-impact
```
- Step 2: Created a components folder inside libs/pages/elewa/social-impact/src/lib.
- Step 3: Created social-impact component inside the components folder using:
```
nx g c social-impact-open-knowledge
```

Fixes # (issue 34)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
Desktop view
![Screenshot from 2023-02-16 14-40-23](https://user-images.githubusercontent.com/106156182/219360208-f42bd737-113e-4184-a69e-edb954adc4d6.png)
 Mobile view
![Screenshot from 2023-02-16 14-40-48](https://user-images.githubusercontent.com/106156182/219360307-20854d0b-13d3-4033-8894-f98af664939c.png)

# How Has This Been Tested?

Step 1: Commented out everything in app.component.html and did the required imports and exports.
Step 2: Ran ```nx serve elewa-group-website``` to start the server and view website for proper editing.
Step 3: Tested how the website's responsiveness using chrome developer tools.


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
