### PR TITLE
✨Feat: Added social impact cooperative section

### DIFF
--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SocialImpactPageComponent } from './pages/social-impact-page/social-impact-page.component';
+import { BannersModule } from '@elewa-group/features/components/banners';
 
 import { SocialImpactRoutingModule } from './social-impact.routing';
 
 @NgModule({
-  imports: [CommonModule,SocialImpactRoutingModule],
+  imports: [CommonModule,SocialImpactRoutingModule, BannersModule],
   declarations: [SocialImpactPageComponent],
 })
 export class SocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
@@ -1,1 +1,1 @@
-<p>social-impact-page works!</p>
+<elewa-group-elewa-group-image-and-text-banner></elewa-group-elewa-group-image-and-text-banner>


### PR DESCRIPTION
# Description

Added a social impact cooperative section as required


Collaborators 
@doreenlulu
@codertinie

To achieve this, we needed to:

```
To re-use the component on [#31 ](https://github.com/italanta/elewa-group/issues/31)
```

Feat # (32) - *Example*: Feat# ([32](https://github.com/italanta/elewa-group/issues/32)

# Screenshot (optional)
Big Screen View
![Screenshot from 2023-02-17 13-05-14](https://user-images.githubusercontent.com/110034881/219614576-95bd0791-d087-4e0b-bfc0-36a6d34afd7b.png)

Phone View
![Screenshot from 2023-02-17 13-05-36](https://user-images.githubusercontent.com/110034881/219614664-59029166-377e-4d68-b165-00dbdc776cab.png)



# How Has This Been Tested?
This was tested using the local server and the browser to ensure it looks as instructed


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
