### PR TITLE
32/social impact cooperative section

### DIFF
--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-cooperative-section/social-impact-cooperative-section.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-cooperative-section/social-impact-cooperative-section.component.html
@@ -1,0 +1,3 @@
+<div class="beyond-business">
+    <elewa-group-elewa-group-image-and-text-banner [backgroundColor]="backgroundColor"></elewa-group-elewa-group-image-and-text-banner>
+</div>

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-cooperative-section/social-impact-cooperative-section.component.spec.ts
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-cooperative-section/social-impact-cooperative-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SocialImpactCooperativeSectionComponent } from './social-impact-cooperative-section.component';
+
+describe('SocialImpactCooperativeSectionComponent', () => {
+  let component: SocialImpactCooperativeSectionComponent;
+  let fixture: ComponentFixture<SocialImpactCooperativeSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SocialImpactCooperativeSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SocialImpactCooperativeSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/social-impact/src/lib/components/social-impact-cooperative-section/social-impact-cooperative-section.component.ts
+++ b/libs/pages/elewa/social-impact/src/lib/components/social-impact-cooperative-section/social-impact-cooperative-section.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-social-impact-cooperative-section',
+  templateUrl: './social-impact-cooperative-section.component.html',
+  styleUrls: ['./social-impact-cooperative-section.component.scss'],
+})
+export class SocialImpactCooperativeSectionComponent {
+  backgroundColor="#ececec"
+}

--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LayoutModule } from '@elewa-group/elements/layout';
+import { BannersModule } from '@elewa-group/features/components/banners';
 import { SocialImpactPageComponent } from './pages/social-impact-page/social-impact-page.component';
 import { SocialImpactHeroSectionComponent } from './components/social-impact-hero-section/social-impact-hero-section.component';
 import { SocialImpactCooperativeSectionComponent } from './components/social-impact-cooperative-section/social-impact-cooperative-section.component';
 import { SocialImpactRoutingModule } from './social-impact.routing';
 
-import { BannersModule } from '@elewa-group/features/components/banners';
 @NgModule({
-  imports: [CommonModule, LayoutModule, SocialImpactRoutingModule, BannersModule],
+  imports: [CommonModule, LayoutModule, BannersModule, SocialImpactRoutingModule],
   declarations: [
     SocialImpactPageComponent,
     SocialImpactHeroSectionComponent,

--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { LayoutModule } from '@elewa-group/elements/layout';
 import { SocialImpactPageComponent } from './pages/social-impact-page/social-impact-page.component';
 import { SocialImpactHeroSectionComponent } from './components/social-impact-hero-section/social-impact-hero-section.component';
-import { SocialImpactRoutingModule } from './social-impact.routing';
 import { SocialImpactCooperativeSectionComponent } from './components/social-impact-cooperative-section/social-impact-cooperative-section.component';
+import { SocialImpactRoutingModule } from './social-impact.routing';
 
 import { BannersModule } from '@elewa-group/features/components/banners';
 @NgModule({

--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -3,9 +3,14 @@ import { CommonModule } from '@angular/common';
 import { SocialImpactPageComponent } from './pages/social-impact-page/social-impact-page.component';
 
 import { SocialImpactRoutingModule } from './social-impact.routing';
+import { SocialImpactCooperativeSectionComponent } from './components/social-impact-cooperative-section/social-impact-cooperative-section.component';
 
+import { BannersModule } from '@elewa-group/features/components/banners';
 @NgModule({
-  imports: [CommonModule,SocialImpactRoutingModule],
-  declarations: [SocialImpactPageComponent],
+  imports: [CommonModule, SocialImpactRoutingModule, BannersModule],
+  declarations: [
+    SocialImpactPageComponent,
+    SocialImpactCooperativeSectionComponent,
+  ],
 })
 export class SocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
@@ -1,1 +1,1 @@
-<p>social-impact-page works!</p>
+<elewa-group-social-impact-cooperative-section></elewa-group-social-impact-cooperative-section>


### PR DESCRIPTION
# Description

Created a section that describes the Social Impact cooperative section that shows an image on the right side, a paragraph of text and a title. This component displays provided text and images side by side on the social impact section using the reusable animated button components in issue https://github.com/italanta/elewa-group/issues/31. 

To achieve this, I needed to:
- Step 1: Create the Social Impact cooperative section component
```
nx g @nrwl/angular:component pages/elewa/social-impact
```
- Make an import of the button module to be reused in the component

Fixes # (issue  https://github.com/italanta/elewa-group/issues/32) 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
Desktop View
![social-desktop](https://user-images.githubusercontent.com/79839603/219617044-8be5656b-85e1-430d-9bb6-608fdb6e6d19.png)


Mobile View
![social-mobile](https://user-images.githubusercontent.com/79839603/219617064-0264ed68-304b-48da-952e-626be37699bd.png)


# How Has This Been Tested?
Step 1: Added the component to social-impact-page.component.html
Step 2: Started the server by running ```nx serve elewa-group-website```
Step 3: Using chrome developer tools to test on the responsiveness of the website


# Checklist:t
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules