### PR TITLE
39/social impact footer section

### DIFF
--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -3,9 +3,18 @@ import { CommonModule } from '@angular/common';
 import { SocialImpactPageComponent } from './pages/social-impact-page/social-impact-page.component';
 
 import { SocialImpactRoutingModule } from './social-impact.routing';
+import { SocialImpactFooteSectionComponent } from './social-impact-foote-section/social-impact-foote-section.component';
+import { LayoutModule } from '@elewa-group/elements/layout';
+import { ButtonsModule } from '@elewa-group/features/components/buttons';
 
 @NgModule({
-  imports: [CommonModule,SocialImpactRoutingModule],
-  declarations: [SocialImpactPageComponent],
+  imports: [
+    CommonModule, 
+    SocialImpactRoutingModule,
+    LayoutModule,
+    ButtonsModule
+  ],
+  declarations: [SocialImpactPageComponent, SocialImpactFooteSectionComponent],
+  exports: [SocialImpactFooteSectionComponent]
 })
 export class SocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
@@ -1,1 +1,0 @@
-<p>social-impact-page works!</p>

--- a/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.html
@@ -1,0 +1,8 @@
+<elewa-group-footer>
+    <div footer class="footer-content">
+        <h4>do you want to be part of our mission?</h4>
+        <div class="mission">
+          <elewa-group-button-with-animation [message]="'Become an investor'" [mode]="'dark'" [action]="'/'"></elewa-group-button-with-animation>
+        </div>
+      </div>
+</elewa-group-footer>

--- a/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.scss
+++ b/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.scss
@@ -1,0 +1,17 @@
+.footer-content {
+    h4 {
+      margin: 0;
+      font-family: var(--elewa-group-website-dmsans-medium);
+      font-size: var(--elewa-group-website-font-size-title-medium);
+      font-weight: var(--elewa-group-website-font-weight-subtitle);
+      text-align: center;
+      margin-bottom: 1rem;
+    }
+  
+    .mission {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 1.2rem;
+    }
+  }
+  

--- a/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.spec.ts
+++ b/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SocialImpactFooteSectionComponent } from './social-impact-foote-section.component';
+
+describe('SocialImpactFooteSectionComponent', () => {
+  let component: SocialImpactFooteSectionComponent;
+  let fixture: ComponentFixture<SocialImpactFooteSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SocialImpactFooteSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SocialImpactFooteSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.ts
+++ b/libs/pages/elewa/social-impact/src/lib/social-impact-foote-section/social-impact-foote-section.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-social-impact-foote-section',
+  templateUrl: './social-impact-foote-section.component.html',
+  styleUrls: ['./social-impact-foote-section.component.scss'],
+})
+export class SocialImpactFooteSectionComponent {}


### PR DESCRIPTION
# Description
worked on this @omaomach
Added the footer to the social impact page. The screenshots were taken from the home page.

Fixes #39 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
![2023-02-17 (10)](https://user-images.githubusercontent.com/102423876/219693986-2803604b-52d2-44f0-b719-3d875eb168c4.png)
![2023-02-17 (11)](https://user-images.githubusercontent.com/102423876/219694009-3ea98821-fcf2-4f30-9ca5-f374f55f4ebc.png)

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
