### PR TITLE
#25/social impact page top banner

### DIFF
--- a/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
+++ b/libs/pages/elewa/social-impact/src/lib/pages-elewa-social-impact.module.ts
@@ -4,8 +4,11 @@ import { SocialImpactPageComponent } from './pages/social-impact-page/social-imp
 
 import { SocialImpactRoutingModule } from './social-impact.routing';
 
+import { LayoutModule } from '@elewa-group/elements/layout';
+
+
 @NgModule({
-  imports: [CommonModule,SocialImpactRoutingModule],
+  imports: [CommonModule,SocialImpactRoutingModule, LayoutModule],
   declarations: [SocialImpactPageComponent],
 })
 export class SocialImpactModule {}

--- a/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
+++ b/libs/pages/elewa/social-impact/src/lib/pages/social-impact-page/social-impact-page.component.html
@@ -1,1 +1,12 @@
-<p>social-impact-page works!</p>
+<div>
+  <elewa-group-elewa-group-main-page>
+    <div mainPage class="home-page">
+      <elewa-group-elewa-hero    
+        [subtitle]="'Social Enterprice'"
+        [title]="'A vehicle for rapid & scalable human development'"
+        [backgroundImg]="'https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690306/elewa-group-website/Images/Mask_Group_17_rjkgrq.png'"
+        [footerText]="''">      
+      </elewa-group-elewa-hero>
+    </div>    
+  </elewa-group-elewa-group-main-page>
+</div>


### PR DESCRIPTION
# Description

We added the social impact header and hero components.

Example
This pull request is part of the work to make it easier for people to know how the i-talanta organisation is impacting the society in which it is involved in. 

To achieve this, we needed to:

```
- Reuse the elewa hero and home components.

```

Fixes # (issue25) - *Example*: Fixes # (https://github.com/italanta/elewa-group/issues/25)[Create social impact page top banner]

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Screenshot 
mobile view
![mobile view](https://user-images.githubusercontent.com/110296805/219936527-c6671f3d-a1a4-4b53-9279-ca146708343a.png)



full view
![screen view](https://user-images.githubusercontent.com/110296805/219936545-7c01a598-fc43-4766-9739-176cb4c370d7.png)



# How Has This Been Tested?

I tested it on different browsers to make sure the application does not break


# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

Worked on this issue with https://github.com/mbuimbogo
