### PR TITLE
:sparkles: Enable passing of multiple paragraphs of text to the compo…

### DIFF
--- a/libs/features/components/banners/src/lib/banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.html
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.html
@@ -2,7 +2,7 @@
     <div class="banner-container {{imagePlacement}}">
         <div id="text-content" class="content">
             <h1 class="title">{{titleText}}</h1>
-            <p>{{paragraphText}}</p>
+            <p class="paragraph" *ngFor="let paragraph of paragraphTexts">{{paragraph}}</p>
         </div>
 
         <div id="img-content" class="content">

--- a/libs/features/components/banners/src/lib/banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.scss
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.scss
@@ -45,6 +45,11 @@
     margin-bottom: 2rem;
 }
 
+#text-and-image-banner #text-content .paragraph {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
 #text-and-image-banner .content#img-content img {
     border-radius: 2rem;
 }

--- a/libs/features/components/banners/src/lib/banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.ts
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component.ts
@@ -7,12 +7,12 @@ import { Component, Input } from '@angular/core';
 })
 export class ElewaGroupImageAndTextBannerComponent {
   @Input() imageURL = 'https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Images/gettyimages-525701055-2048x2048_g7nbt1.png'
-  @Input() paragraphText = `Elewa's businesses have one common objective, to
+  @Input() paragraphTexts = [`Elewa's businesses have one common objective, to
                             unlock true potential of individuals, teams, and
                             communities. All our talents are enrolled in a personal
                             growth track. In turn, they contribute teir own growth
                             towards teh growth of others, the group and their
-                            communities.`
+                            communities.`]
   @Input() titleText = `A cooperative mindset`
   @Input() imagePlacement = 'right'
   @Input() backgroundColor = 'grey'


### PR DESCRIPTION
# Description
This change is an enhancement to issue #31 . It enables the banner component developed in issue #31 to accept multiple paragraphs in stead of just 1 as in the initial case. That has been done by changing the input **paragraphText** from string type to an array

- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)
![Screenshot from 2023-02-20 11-30-24](https://user-images.githubusercontent.com/81687679/220052918-23a97724-5d5d-4a69-b08d-7c41d7b6ad8c.png)


# How Has This Been Tested?
By passing adding more string texts to the **paragraphText** array and examining whether all of them have been displayed as part of a different paragraph


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
