### PR TITLE
Issue22/ft history carousel

### DIFF
--- a/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.html
@@ -1,0 +1,1 @@
+<p>timeline-carousel works!</p>

--- a/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.html
@@ -1,1 +1,7 @@
-<p>timeline-carousel works!</p>
+<div class="wrapper">
+    <h1 class="title" style="font-size: var(--elewa-group-website-font-size-title)">
+        Our History 
+    </h1>
+    <elewa-group-elewa-horizontal-timeline-carousel></elewa-group-elewa-horizontal-timeline-carousel>
+    <p class="paragraph">Learn more about <span>Elewa's social impact</span></p>
+</div>

--- a/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.scss
+++ b/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.scss
@@ -13,7 +13,7 @@
     font-size: var(--elewa-group-website-font-size-title);
     display: flex;
     flex-direction: column;
-    padding-bottom: 100px;
+    padding-bottom: 250px;
 }
 span{
     font-family: var(--elewa-group-website-dmsans-bold);

--- a/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.scss
+++ b/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.scss
@@ -1,0 +1,20 @@
+.wrapper{
+    padding: 10px;
+    padding-top: 50px;
+}
+.title{
+    font-weight: var(--elewa-group-website-font-weight-title);
+    font-family: var(--elewa-group-website-dmsans-regular);
+    padding-left: 100px;
+}
+.paragraph{
+    text-align: center;
+    font-family: var(--elewa-group-website-dmsans-regular);
+    font-size: var(--elewa-group-website-font-size-title);
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 100px;
+}
+span{
+    font-family: var(--elewa-group-website-dmsans-bold);
+}

--- a/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.spec.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TimelineCarouselComponent } from './timeline-carousel.component';
+
+describe('TimelineCarouselComponent', () => {
+  let component: TimelineCarouselComponent;
+  let fixture: ComponentFixture<TimelineCarouselComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TimelineCarouselComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimelineCarouselComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/timeline-carousel/timeline-carousel.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-timeline-carousel',
+  templateUrl: './timeline-carousel.component.html',
+  styleUrls: ['./timeline-carousel.component.scss'],
+})
+export class TimelineCarouselComponent {}

--- a/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
+++ b/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
@@ -4,9 +4,9 @@ import { CommonModule } from '@angular/common';
 
 import { ElewaAboutUsLocationSectionComponent } from './components/elewa-about-us-location-section/elewa-about-us-location-section.component';
 
-import { GoogleMapsModule } from '@angular/google-maps'
+import { GoogleMapsModule } from '@angular/google-maps';
 
-import { ButtonsModule } from "@elewa-group/features/components/buttons"
+import { ButtonsModule } from '@elewa-group/features/components/buttons';
 import { LayoutModule } from '@elewa-group/elements/layout';
 
 import { TeamMembersCarouselComponent } from './components/team-members-carousel/team-members-carousel.component';
@@ -22,6 +22,7 @@ import { AboutUsRoutingModule } from './about-us.routing';
 
 // eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { ElewaHorizontalTimelineCarouselComponent } from 'libs/features/components/ui-lists/src/lib/elewa-horizontal-timeline-carousel/elewa-horizontal-timeline-carousel.component';
+import { TimelineCarouselComponent } from './components/timeline-carousel/timeline-carousel.component';
 
 @NgModule({
   imports: [
@@ -29,7 +30,7 @@ import { ElewaHorizontalTimelineCarouselComponent } from 'libs/features/componen
     ButtonsModule,
     CommonModule,
     LayoutModule,
-    AboutUsRoutingModule
+    AboutUsRoutingModule,
   ],
   declarations: [
     TeamMembersCarouselComponent,
@@ -38,11 +39,9 @@ import { ElewaHorizontalTimelineCarouselComponent } from 'libs/features/componen
     AboutUsCultureComponent,
     AboutUsPageComponent,
     ElewaAboutUsLocationSectionComponent,
-    ElewaHorizontalTimelineCarouselComponent
+    ElewaHorizontalTimelineCarouselComponent,
+    TimelineCarouselComponent,
   ],
-  exports: [
-    TeamMembersCarouselComponent,
-    ElewaAboutUsLocationSectionComponent
-  ],
+  exports: [TeamMembersCarouselComponent, ElewaAboutUsLocationSectionComponent],
 })
 export class AboutUsModule {}

--- a/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
+++ b/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
@@ -20,6 +20,9 @@ import { PrevDirective } from './directives/prev.directive';
 
 import { AboutUsRoutingModule } from './about-us.routing';
 
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import { ElewaHorizontalTimelineCarouselComponent } from 'libs/features/components/ui-lists/src/lib/elewa-horizontal-timeline-carousel/elewa-horizontal-timeline-carousel.component';
+
 @NgModule({
   imports: [
     GoogleMapsModule,
@@ -34,7 +37,8 @@ import { AboutUsRoutingModule } from './about-us.routing';
     PrevDirective,
     AboutUsCultureComponent,
     AboutUsPageComponent,
-    ElewaAboutUsLocationSectionComponent
+    ElewaAboutUsLocationSectionComponent,
+    ElewaHorizontalTimelineCarouselComponent
   ],
   exports: [
     TeamMembersCarouselComponent,

--- a/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
+++ b/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
@@ -5,6 +5,7 @@
 
       <elewa-group-about-us-culture></elewa-group-about-us-culture>
       <elewa-group-team-members-carousel></elewa-group-team-members-carousel>
+      <elewa-group-timeline-carousel></elewa-group-timeline-carousel>
     </div>
   </elewa-group-elewa-group-main-page> 
 </div>


### PR DESCRIPTION
# Description
A carousel that can display a history timeline of the organisation

To achieve this, we needed to:

Reuse the component in -timeline carousel (reuse watchhttps://github.com/italanta/elewa-group/issues/21 )
Add a title
Have a call to action section

Fixes # (issue) - https://github.com/italanta/elewa-group/issues/22

## Type of change
This is a feature change 

# Screenshot (optional)

![history](https://user-images.githubusercontent.com/109944021/220057478-fe54dacc-ad40-4744-864b-826f3ecf6443.png)



![calltoaction](https://user-images.githubusercontent.com/109944021/220057555-7ebe1737-d4af-4222-a65c-1c2933ec78e6.png)






# How Has This Been Tested?

Checked for pixel accuracy in my browser and made sure no errors are arising


# Checklist:
- [ ✔️] My code follows the style guidelines of this project
- [✔️ ] I have performed a self-review of my code
- [✔️ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✔️ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [✔️ ] New and existing unit tests pass locally with my changes
- [ ✔️] Any dependent changes have been merged and published in downstream modules
