### PR TITLE
246/invest stakeholder section

### DIFF
--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component.html
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component.html
@@ -1,0 +1,1 @@
+<elewa-group-elewa-group-image-and-text-banner [imageURL]="imageURL" [imagePlacement]="imagePlacement" [titleText]="titleText" [backgroundColor]="backgroundColor" [paragraphTexts]="paragraphTexts"></elewa-group-elewa-group-image-and-text-banner>

--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component.spec.ts
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaInvestStakeholderSectionComponent } from './elewa-invest-stakeholder-section.component';
+
+describe('ElewaInvestStakeholderSectionComponent', () => {
+  let component: ElewaInvestStakeholderSectionComponent;
+  let fixture: ComponentFixture<ElewaInvestStakeholderSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaInvestStakeholderSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaInvestStakeholderSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component.ts
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-invest-stakeholder-section',
+  templateUrl: './elewa-invest-stakeholder-section.component.html',
+  styleUrls: ['./elewa-invest-stakeholder-section.component.scss'],
+})
+export class ElewaInvestStakeholderSectionComponent {
+  imageURL = 'https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690303/elewa-group-website/Images/IMG_6523_vabpyo.png'
+  paragraphTexts: string[] = ['At the heart of Elewa lies the structure Elewa NV. Based in Brussels, Belgium, Elewa NV is a private holding company which controls the assets of all Elewa activities.', 'Elewa NV is owned and controlled by Elewa\'s founder, a small community of investors which share in the vision of Elewa and Elewa employees based throughout the activities of the group']
+  titleText = `Elewa NV, a multi-stakeholder cooperation`
+  imagePlacement = 'left'
+  backgroundColor = 'var(--elewa-group-website-color)'
+}

--- a/libs/pages/elewa/invest/src/lib/pages-elewa-invest.module.ts
+++ b/libs/pages/elewa/invest/src/lib/pages-elewa-invest.module.ts
@@ -3,9 +3,12 @@ import { CommonModule } from '@angular/common';
 import { InvestPageComponent } from './pages/invest-page/invest-page.component';
 
 import { InvestRoutingModule } from './invest.routing';
+import { ElewaInvestStakeholderSectionComponent } from './components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component';
+
+import { BannersModule } from '@elewa-group/features/components/banners';
 
 @NgModule({
-  imports: [CommonModule, InvestRoutingModule],
-  declarations: [InvestPageComponent],
+  imports: [CommonModule, BannersModule, InvestRoutingModule],
+  declarations: [InvestPageComponent, ElewaInvestStakeholderSectionComponent],
 })
 export class InvestPageModule {}

--- a/libs/pages/elewa/invest/src/lib/pages-elewa-invest.module.ts
+++ b/libs/pages/elewa/invest/src/lib/pages-elewa-invest.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { BannersModule } from '@elewa-group/features/components/banners';
 import { InvestPageComponent } from './pages/invest-page/invest-page.component';
 
 import { InvestRoutingModule } from './invest.routing';
 import { ElewaInvestStakeholderSectionComponent } from './components/elewa-invest-stakeholder-section/elewa-invest-stakeholder-section.component';
 
-import { BannersModule } from '@elewa-group/features/components/banners';
 
 @NgModule({
   imports: [CommonModule, BannersModule, InvestRoutingModule],

--- a/libs/pages/elewa/invest/src/lib/pages/invest-page/invest-page.component.html
+++ b/libs/pages/elewa/invest/src/lib/pages/invest-page/invest-page.component.html
@@ -1,1 +1,1 @@
-<p>invest-page works!</p>
+<elewa-group-elewa-invest-stakeholder-section></elewa-group-elewa-invest-stakeholder-section>


### PR DESCRIPTION
# Description

Created a section that describes the Invest Stakeholder section that shows an image on the right side, a paragraph of text and a title. This component displays provided text and images side by side on the invest stakeholder section using the reusable banner in issue https://github.com/italanta/elewa-group/issues/31. 

To achieve this, I needed to:
- Step 1: Create the Elewa Invest Stakeholder component
```
nx g @nrwl/angular:component pages/elewa/invest/elewa-invest-stakeholder-section
```
- Make an import of the layout module to be reused in the component

Fixes # (issue  https://github.com/italanta/elewa-group/issues/246) 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
Desktop View
![stakeholder-desktop](https://user-images.githubusercontent.com/79839603/220603210-60adcf3a-bc13-4441-b8bc-594b8de28e95.png)

Mobile View
![stakeholder-mobile](https://user-images.githubusercontent.com/79839603/220603258-bce126fb-9799-43b0-a1a4-e658e9e26648.png)

# How Has This Been Tested?
Step 1: Added the component to invest-page.component.html
Step 2: Started the server by running ```nx serve elewa-group-website```
Step 3: Using chrome developer tools to test on the responsiveness of the website


# Checklist:t
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules