### PR TITLE
247/ Invest creative-hub Section

### DIFF
--- a/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
+++ b/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
@@ -1,0 +1,1 @@
+<p>elewa-invest-creative-hub-section works!</p>

--- a/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
+++ b/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
@@ -1,1 +1,8 @@
-<p>elewa-invest-creative-hub-section works!</p>
+<!-- <p>elewa-invest-creative-hub-section works!</p> -->
+<elewa-group-elewa-group-image-and-text-banner
+[titleText] ="title"
+[paragraphTexts] = "paragraphs"
+[imageURL]="imgURL"
+[ngStyle]="{ 'color': textColor}"
+[backgroundColor]="bgColor"
+></elewa-group-elewa-group-image-and-text-banner>

--- a/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.spec.ts
+++ b/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaInvestCreativeHubSectionComponent } from './elewa-invest-creative-hub-section.component';
+
+describe('ElewaInvestCreativeHubSectionComponent', () => {
+  let component: ElewaInvestCreativeHubSectionComponent;
+  let fixture: ComponentFixture<ElewaInvestCreativeHubSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaInvestCreativeHubSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaInvestCreativeHubSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
+++ b/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
@@ -5,4 +5,11 @@ import { Component } from '@angular/core';
   templateUrl: './elewa-invest-creative-hub-section.component.html',
   styleUrls: ['./elewa-invest-creative-hub-section.component.scss'],
 })
-export class ElewaInvestCreativeHubSectionComponent {}
+export class ElewaInvestCreativeHubSectionComponent {
+  title= "Elewa Creative hub"
+  paragraphs = ["The Elewa Creative Hub Lies at the heart of our organization. A two-acre property center of Nairobi's creative district, the hub connects all Elewa's Activities under a single banner.", "", "Through partnerships with creative community, the Elewa Hub organizes vibrant activites tht bring talents from different fields (tech, business, art, fashion) to nurture continuous innovation"]
+  imagePosition = "right"
+  imgURL= "https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690302/elewa-group-website/Images/Mask_Group_20_yshsq2.png"
+  bgColor = "white"
+  textColor= "black"
+}

--- a/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
+++ b/libs/pages/elewa/invest/src/lib/pages/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-invest-creative-hub-section',
+  templateUrl: './elewa-invest-creative-hub-section.component.html',
+  styleUrls: ['./elewa-invest-creative-hub-section.component.scss'],
+})
+export class ElewaInvestCreativeHubSectionComponent {}


### PR DESCRIPTION
# Description
Create a section that describes the investors creative hub section to the user.

To achieve this, we needed to:

```
- Make it visible on the page so users can notice it easily
```

Fixes #247 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Screenshot
### Mobile 

![image](https://user-images.githubusercontent.com/99868443/220840996-696a369f-f54a-4e93-acd0-851cb28c86e0.png)

### Desktop
![image](https://user-images.githubusercontent.com/99868443/220841069-c83579e9-b685-47c2-876a-ad38ed16d28c.png)


# How Has This Been Tested?
- [x] Tested Via Chrome Browser
- [x] Tested Via Bing Browser


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
