### PR TITLE
12 create the home impact section

### DIFF
--- a/libs/features/components/buttons/src/lib/elewa-group-button-with-animation/elewa-group-button-with-animation.component.css
+++ b/libs/features/components/buttons/src/lib/elewa-group-button-with-animation/elewa-group-button-with-animation.component.css
@@ -10,6 +10,7 @@
     color: var(--elewa-group-website-color-card);
     background-color: var(--elewa-group-website-color-primary);
     cursor: pointer;
+    min-width: 100%;
 }
 
 .button-with-animation span{
@@ -17,6 +18,7 @@
     transition: all 0.3s;
     transition-delay: 0.05;
     letter-spacing: 0px;
+    margin-left: auto;
 }
 
 .button-with-animation .right-arrow-container{
@@ -29,6 +31,8 @@
     align-items: center;
     left: 0%;
     transition: all 0.3s;
+    margin-right: 0;
+    margin-left: auto;
 }
 
 .button-with-animation:hover  .right-arrow-container{

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.html
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.html
@@ -1,0 +1,18 @@
+<div class="impact-container">
+    <div class="column1">
+        <div class="titlediv">
+            <h1>Growing Capital Impacting Lives </h1>
+        </div>
+        <div class="pdiv" >
+            <p>Elewaa is proof that growing capital and impacting lives can work well together.</p>
+            <p>Our group owned and managed by our founder, our employees (across our brands) and our network of 56 passionate angel investors.</p>
+        </div>
+        <div class="button-div">
+            <elewa-group-button-with-animation class="button" [message]="'Learn more'" [mode]="'dark'" [action]="'/'"></elewa-group-button-with-animation>
+            <elewa-group-button-with-animation class="button" [message]="'Become an angel investor'" [mode]="'light'" [action]="'/'"></elewa-group-button-with-animation>
+        </div>
+    </div>
+    <div class="column2" >
+        <img src='https://res.cloudinary.com/db15gy9h6/image/upload/v1675949508/Screenshot_from_2023-02-09_16-26-20_zdx7mn.png' alt="image">
+    </div>
+</div>

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
@@ -15,12 +15,12 @@
 }
 .titlediv, h1{
     font-weight: var(--elewa-group-website-font-weight-title);
-    font-size: 30px;
+    font-size: 34px;
     font-family: var(--elewa-group-website-dmsans-bold);
     padding-bottom: 10px;
 }
 .pdiv, p{
-    font-size: 20px;
+    font-size: 24px;
     font-family: var(--elewa-group-website-dmsans-regular);
     padding-bottom: 5%;
 }
@@ -40,9 +40,8 @@
     display: flex;
 }
 .button{
-    padding-right: 20px;
-    margin-right: auto;
-    margin-left: auto;
+    margin-right: 10%;
+    margin-left: 0%;
 }
 
 @media screen and (max-width: 850px)  {
@@ -60,15 +59,17 @@
     .button {
         padding-bottom: 20px;
         width: 290px;
+        margin-left: auto;
+        margin-right: auto;
     }
     .button-div{
         flex-direction: column;        
     }
     .titlediv,h1{
-        font-size: 30px;
+        font-size: 20px;
     }
     .pdiv, p{
-        font-size: 18px;
+        font-size: 15px;
     }
     .column2,img{
         width: 300px;

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
@@ -3,8 +3,8 @@
     display: flex;
     align-items: center;
     padding-bottom: 10%;
-    padding-top: 10%;
-    height: 1000px;
+    padding-top: 15%;
+    height: 60vh;
     
 }
 .column2,img{
@@ -41,7 +41,8 @@
 }
 .button{
     padding-right: 20px;
-    
+    margin-right: auto;
+    margin-left: auto;
 }
 
 @media screen and (max-width: 850px)  {

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
@@ -3,34 +3,38 @@
     display: flex;
     align-items: center;
     padding-bottom: 10%;
-    padding-top: 20%;
+    padding-top: 10%;
     height: 1000px;
     
 }
 .column2,img{
     border-radius: 10px;
-    width: 500px;
-    height: 800px;
+    width: 300px;
+    height: 500px;
     object-fit: cover;
 }
 .titlediv, h1{
     font-weight: var(--elewa-group-website-font-weight-title);
-    font-size: 60px;
+    font-size: 30px;
     font-family: var(--elewa-group-website-dmsans-bold);
     padding-bottom: 10px;
 }
 .pdiv, p{
-    font-size: 30px;
+    font-size: 20px;
     font-family: var(--elewa-group-website-dmsans-regular);
     padding-bottom: 5%;
 }
 .column2{
     flex: 1;
+    margin-left: auto;
+    margin-right: auto;
 }
 .column1{
     flex: 1;
     padding-left: 15%;
     padding-right: 10%;
+    margin-left: auto;
+    margin-right: auto;
 }
 .button-div{
     display: flex;

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.scss
@@ -1,0 +1,72 @@
+.impact-container{
+    background-color: none;
+    display: flex;
+    align-items: center;
+    padding-bottom: 10%;
+    padding-top: 20%;
+    height: 1000px;
+    
+}
+.column2,img{
+    border-radius: 10px;
+    width: 500px;
+    height: 800px;
+    object-fit: cover;
+}
+.titlediv, h1{
+    font-weight: var(--elewa-group-website-font-weight-title);
+    font-size: 60px;
+    font-family: var(--elewa-group-website-dmsans-bold);
+    padding-bottom: 10px;
+}
+.pdiv, p{
+    font-size: 30px;
+    font-family: var(--elewa-group-website-dmsans-regular);
+    padding-bottom: 5%;
+}
+.column2{
+    flex: 1;
+}
+.column1{
+    flex: 1;
+    padding-left: 15%;
+    padding-right: 10%;
+}
+.button-div{
+    display: flex;
+}
+.button{
+    padding-right: 20px;
+    
+}
+
+@media screen and (max-width: 850px)  {
+    .impact-container{
+        flex-direction: column;
+        height: 100%;
+        width: 100%;
+        text-align: center;
+        justify-items: center;
+        
+    }
+    .column1{
+        width: 100%;
+    }
+    .button {
+        padding-bottom: 20px;
+        width: 290px;
+    }
+    .button-div{
+        flex-direction: column;        
+    }
+    .titlediv,h1{
+        font-size: 30px;
+    }
+    .pdiv, p{
+        font-size: 18px;
+    }
+    .column2,img{
+        width: 300px;
+        height: 400px;
+    }
+}

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.spec.ts
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomeImpactSectionComponent } from './home-impact-section.component';
+
+describe('HomeImpactSectionComponent', () => {
+  let component: HomeImpactSectionComponent;
+  let fixture: ComponentFixture<HomeImpactSectionComponent>;
+  ;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HomeImpactSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomeImpactSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.ts
+++ b/libs/pages/elewa/home/src/lib/components/home-impact-section/home-impact-section.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-home-impact-section',
+  templateUrl: './home-impact-section.component.html',
+  styleUrls: ['./home-impact-section.component.scss'],
+})
+export class HomeImpactSectionComponent {};

--- a/libs/pages/elewa/home/src/lib/features-elewa-home.module.ts
+++ b/libs/pages/elewa/home/src/lib/features-elewa-home.module.ts
@@ -3,12 +3,14 @@ import { CommonModule, NgOptimizedImage } from '@angular/common';
 
 import { LayoutModule } from '@elewa-group/elements/layout';
 import { CardsModule } from '@elewa-group/features/components/cards';
+import { ButtonsModule } from '@elewa-group/features/components/buttons';
 
 import { HomeHeroSectionComponent } from './components/home-hero-section/home-hero-section.component';
 import { HomeJobsSectionComponent } from './components/home-jobs-section/home-jobs-section.component';
 import { TeamAndPartnersComponent } from './components/team-and-partners/team-and-partners.component';
 import { ActivitySectionComponent } from './components/activity-section/activity-section.component';
 import { HomePageLanderComponent} from './components/home-page-lander/home-page-lander.component';
+import { HomeImpactSectionComponent } from './components/home-impact-section/home-impact-section.component';
 
 import { HomePageComponent } from './pages/home-page/home-page.component';
 
@@ -23,7 +25,8 @@ import { HomeRoutingModule } from './home.routing';
     LayoutModule,
     NgOptimizedImage,
     CardsModule,
-    HomeRoutingModule
+    HomeRoutingModule,
+    ButtonsModule
   ],
   declarations: [
     HomePageComponent,
@@ -33,7 +36,8 @@ import { HomeRoutingModule } from './home.routing';
     ActivitySectionComponent,
     HomePageLanderComponent,
     NextDirective,
-    PrevDirective
+    PrevDirective,
+    HomeImpactSectionComponent
   ],
   exports: [HomePageComponent, HomeHeroSectionComponent,HomeJobsSectionComponent,HomePageLanderComponent],
 })

--- a/libs/pages/elewa/home/src/lib/pages/home-page/home-page.component.html
+++ b/libs/pages/elewa/home/src/lib/pages/home-page/home-page.component.html
@@ -5,6 +5,7 @@
       <elewa-group-home-hero-section></elewa-group-home-hero-section>
       <elewa-group-activity-section></elewa-group-activity-section>
       <elewa-group-team-and-partners></elewa-group-team-and-partners>
+      <elewa-group-home-impact-section></elewa-group-home-impact-section>
       <elewa-group-home-jobs-section></elewa-group-home-jobs-section>
 
     </div>


### PR DESCRIPTION
This pull request is part of the work to make it easier for the user to view the elewa impact. 

To achieve this, we needed to:

-Create the home impact component
-Add a router link to the component
-Display it on the homepage

Fixes # [`issue 12`](https://github.com/italanta/elewa-group/issues/12)


## Type of change


- ✅ New feature (non-breaking change which adds functionality)


# Screenshot (optional)

![Screenshot from 2023-02-23 11-56-33](https://user-images.githubusercontent.com/109956415/220862001-4e7f8b02-b55e-4e44-8606-3d0ee6aeb377.png)



![Screenshot from 2023-02-23 11-58-17](https://user-images.githubusercontent.com/109956415/220862042-3a017eea-b433-422a-8d4c-7fd91303ee2b.png)






# Checklist:
- ✅ My code follows the style guidelines of this project
- ✅ I have performed a self-review of my code
- ✅ I have commented my code, particularly in hard-to-understand areas
- ✅ I have made corresponding changes to the documentation
- ✅ My changes generate no new warnings
- ✅ I have added tests that prove my fix is effective or that my feature works
- ✅ New and existing unit tests pass locally with my changes
- ✅ Any dependent changes have been merged and published in downstream modules
