### PR TITLE
#247/invest creative hub section

### DIFF
--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
@@ -1,0 +1,1 @@
+<p>elewa-invest-creative-hub-section works!</p>

--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.html
@@ -1,1 +1,10 @@
-<p>elewa-invest-creative-hub-section works!</p>
+<div class="beyond-business">
+    <elewa-group-elewa-group-image-and-text-banner
+    [titleText]="titleText"
+    [imagePlacement]="'right'"
+    [imageURL]="imageURL"
+    [paragraphTexts]="paragraphTexts"
+    [backgroundColor]="backgroundColor"
+    >
+</elewa-group-elewa-group-image-and-text-banner>
+</div>

--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.spec.ts
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaInvestCreativeHubSectionComponent } from './elewa-invest-creative-hub-section.component';
+
+describe('ElewaInvestCreativeHubSectionComponent', () => {
+  let component: ElewaInvestCreativeHubSectionComponent;
+  let fixture: ComponentFixture<ElewaInvestCreativeHubSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaInvestCreativeHubSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaInvestCreativeHubSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
@@ -5,4 +5,18 @@ import { Component } from '@angular/core';
   templateUrl: './elewa-invest-creative-hub-section.component.html',
   styleUrls: ['./elewa-invest-creative-hub-section.component.scss'],
 })
-export class ElewaInvestCreativeHubSectionComponent {}
+export class ElewaInvestCreativeHubSectionComponent {
+  imageURL = 'https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690302/elewa-group-website/Images/Mask_Group_20_yshsq2.png'
+  paragraphTexts = [`The Elewa Creative Hub lise at the heart of our organization. A two-acre
+  property in the center of Nairobi's creative district, the hub connects 
+  all Elewa's activities under a single banner.`,
+
+  `Through partnerships with the creative community, the Elewa Hub organizes 
+  vibrant activities that bring together talents from different fields
+  (tech, business, art, fashion) to nurture continuous innovation.`
+]
+  
+  titleText = `Elewa Creative hub`
+  imagePlacement = 'right'
+  backgroundColor = 'white'
+}

--- a/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
+++ b/libs/pages/elewa/invest/src/lib/components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-invest-creative-hub-section',
+  templateUrl: './elewa-invest-creative-hub-section.component.html',
+  styleUrls: ['./elewa-invest-creative-hub-section.component.scss'],
+})
+export class ElewaInvestCreativeHubSectionComponent {}

--- a/libs/pages/elewa/invest/src/lib/pages-elewa-invest.module.ts
+++ b/libs/pages/elewa/invest/src/lib/pages-elewa-invest.module.ts
@@ -4,9 +4,15 @@ import { InvestPageComponent } from './pages/invest-page/invest-page.component';
 
 import { InvestRoutingModule } from './invest.routing';
 import { ElewaInvestDetailSectionComponent } from './components/elewa-invest-detail-section/elewa-invest-detail-section.component';
+import { ElewaInvestCreativeHubSectionComponent } from './components/elewa-invest-creative-hub-section/elewa-invest-creative-hub-section.component';
+import { BannersModule } from '@elewa-group/features/components/banners';
 
 @NgModule({
-  imports: [CommonModule, InvestRoutingModule],
-  declarations: [InvestPageComponent, ElewaInvestDetailSectionComponent],
+  imports: [CommonModule, InvestRoutingModule, BannersModule],
+  declarations: [
+    InvestPageComponent,
+    ElewaInvestDetailSectionComponent,
+    ElewaInvestCreativeHubSectionComponent,
+  ]
 })
 export class InvestPageModule {}

--- a/libs/pages/elewa/invest/src/lib/pages/invest-page/invest-page.component.html
+++ b/libs/pages/elewa/invest/src/lib/pages/invest-page/invest-page.component.html
@@ -1,2 +1,3 @@
 <elewa-group-elewa-invest-hero></elewa-group-elewa-invest-hero>
 <elewa-group-elewa-invest-detail-section></elewa-group-elewa-invest-detail-section>
+<elewa-group-elewa-invest-creative-hub-section></elewa-group-elewa-invest-creative-hub-section>

--- a/libs/pages/elewa/invest/src/lib/pages/invest-page/invest-page.component.html
+++ b/libs/pages/elewa/invest/src/lib/pages/invest-page/invest-page.component.html
@@ -1,1 +1,2 @@
 <elewa-group-elewa-invest-detail-section></elewa-group-elewa-invest-detail-section>
+<elewa-group-elewa-invest-creative-hub-section></elewa-group-elewa-invest-creative-hub-section>


### PR DESCRIPTION
# Description

Worked on the elewa creative section.


Example
This pull request implements the elewa creative section component.

To achieve this, we needed to:

```
- Reuse the issue #31 banner component.

```

Fixes # (issue) - *Example*: Fixes # ([S4Y-400](https://www.w3.org/Provider/Style/dummy.html), [S4Y-100](https://www.w3.org/Provider/Style/dummy.html))

## Type of change
- [ ] New feature



# Screenshot (optional)
screen view
![Screen view](https://user-images.githubusercontent.com/110296805/220861529-e26bc80d-6403-4ed6-a106-cbe867242132.png)


mobile view
![mobile view](https://user-images.githubusercontent.com/110296805/220861695-2cbec3b0-7b04-4710-b6c6-d7a50a72ae80.png)
![mobile view](https://user-images.githubusercontent.com/110296805/220861732-5a36cfcb-9a8d-4cb8-99fc-aff49d6aa7f8.png)


# How Has This Been Tested?

We ran it on different browsers to make sure it does not break.



# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

