### PR TITLE
Issue 244/ft key figure card

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -4,6 +4,7 @@
     "elements-layout": "libs/elements/layout",
     "elewa-group-website": "apps/elewa-group-website",
     "features-components-banners": "libs/features/components/banners",
+    "features-components-cards": "libs/features/components/cards",
     "features-components-ui-lists": "libs/features/components/ui-lists",
     "pages-elewa-about-us": "libs/pages/elewa/about-us",
     "pages-elewa-activities": "libs/pages/elewa/activities",

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
@@ -1,0 +1,1 @@
+<p>elewa-key-figure-card works!</p>

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="cardSection">
-        <div class="figure" isImage>
+        <div class="figure" *ngIf="isImage">
             <img src={{figure}} alt="">
             <p class="desc">{{description}}</p>
         </div>

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
@@ -1,1 +1,8 @@
-<p>elewa-key-figure-card works!</p>
+<div class="container">
+    <div class="cardSection">
+        <div class="figure" isImage>
+            <img src={{figure}} alt="">
+            <p class="desc">{{description}}</p>
+        </div>
+    </div>    
+</div>

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
@@ -1,8 +1,14 @@
 <div class="container">
     <div class="cardSection">
-        <div class="figure" *ngIf="isImage">
+        <div class="figure" *ngIf="isImage; else noImage">
             <img src={{figure}} alt="">
             <p class="desc">{{description}}</p>
         </div>
+        <ng-template #noImage>
+            <div class="text">
+                <h1>10</h1>
+                <h3>M</h3>
+            </div>
+        </ng-template>
     </div>    
 </div>

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.scss
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.scss
@@ -16,6 +16,8 @@ img{
     font-weight: var(--elewa-group-website-font-size-description);
     font-family: var(--elewa-group-website-dmsans-regular);
     padding-top: 20px;
+    padding: 30px 30px;
+    text-align: center;
 }
 @media screen and (min-device-width: 768px) and (max-device-width: 1024px) {
 

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.scss
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.scss
@@ -1,0 +1,39 @@
+.wrapper{
+    align-items: center;
+}
+.figure{
+    width: 300px;
+    height: 300px;
+    border-radius: 5%;
+    border: 1px solid gray;
+    padding-top: 100px;  
+    text-align: center;
+}
+img{
+    text-align: center;
+}
+.desc{
+    font-weight: var(--elewa-group-website-font-size-description);
+    font-family: var(--elewa-group-website-dmsans-regular);
+    padding-top: 20px;
+}
+@media screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+
+    .container{
+       display: flex;
+       flex-wrap: wrap;
+       align-items: center;
+    }
+    .figure{
+        width: 350px;
+        height: 350px;
+    }
+}
+@media screen and (min-device-width: 480px) and (orientation: portrait) {
+
+    .container{
+       display: flex;
+       flex-direction: column;
+       margin-left: 100px;
+    }
+}

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.scss
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.scss
@@ -19,6 +19,15 @@ img{
     padding: 30px 30px;
     text-align: center;
 }
+.text{
+    font-weight: var(--elewa-group-website-font-weight-title-medium);
+    font-family: var(--elewa-group-website-dmsans-bold);
+}
+h1,h3 {
+      margin: 0;
+      padding: 0;
+      display: inline;
+}
 @media screen and (min-device-width: 768px) and (max-device-width: 1024px) {
 
     .container{

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.spec.ts
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaKeyFigureCardComponent } from './elewa-key-figure-card.component';
+
+describe('ElewaKeyFigureCardComponent', () => {
+  let component: ElewaKeyFigureCardComponent;
+  let fixture: ComponentFixture<ElewaKeyFigureCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaKeyFigureCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaKeyFigureCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'elewa-group-elewa-key-figure-card',
   templateUrl: './elewa-key-figure-card.component.html',
   styleUrls: ['./elewa-key-figure-card.component.scss'],
 })
-export class ElewaKeyFigureCardComponent {}
+export class ElewaKeyFigureCardComponent  {
+  @Input () figure = "https://i.postimg.cc/wxnQLbYY/nextsteps.png"
+  @Input () description?: string
+  @Input () isImage: boolean
+}

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-key-figure-card',
+  templateUrl: './elewa-key-figure-card.component.html',
+  styleUrls: ['./elewa-key-figure-card.component.scss'],
+})
+export class ElewaKeyFigureCardComponent {}

--- a/libs/features/components/cards/src/lib/features-components-cards.module.ts
+++ b/libs/features/components/cards/src/lib/features-components-cards.module.ts
@@ -1,12 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ElewaGroupCardComponent } from './cards/elewa-group-card/elewa-group-card.component';
-import { ElewaVerticalIconAndTextComponent } from './cards/elewa-vertical-icon-and-text/elewa-vertical-icon-and-text.component'
-
+import { ElewaVerticalIconAndTextComponent } from './cards/elewa-vertical-icon-and-text/elewa-vertical-icon-and-text.component';
+import { ElewaKeyFigureCardComponent } from './cards/elewa-key-figure-card/elewa-key-figure-card.component';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent],
-  exports: [ ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent]
+  declarations: [
+    ElewaGroupCardComponent,
+    ElewaVerticalIconAndTextComponent,
+    ElewaKeyFigureCardComponent,
+  ],
+  exports: [ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent],
 })
 export class CardsModule {}

--- a/libs/features/components/cards/src/lib/features-components-cards.module.ts
+++ b/libs/features/components/cards/src/lib/features-components-cards.module.ts
@@ -11,6 +11,6 @@ import { ElewaKeyFigureCardComponent } from './cards/elewa-key-figure-card/elewa
     ElewaVerticalIconAndTextComponent,
     ElewaKeyFigureCardComponent,
   ],
-  exports: [ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent],
+  exports: [ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent, ElewaKeyFigureCardComponent],
 })
 export class CardsModule {}


### PR DESCRIPTION
# Description
This issue asks for component that can be used to show key figures across the website.

To achieve this, we needed to:

```
- Have inputs for the figure, text and a boolean for whether an image has been provided or not.
- Export the component for reusability
- Description input is optional
```

Fixes # (issue) -https://github.com/italanta/elewa-group/issues/244
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Screenshot (optional)

![keycardbigscreen](https://user-images.githubusercontent.com/109944021/220877248-d664679c-3f65-4e89-b75d-2eb617c0e197.png)

#Cards with a description and without one.

![cards](https://user-images.githubusercontent.com/109944021/220883563-30faf5e7-23d0-48a8-9d13-8bf650845e17.png)

# How Has This Been Tested?
Tried adding various inputs and checking if I have any errors on the browser- Which did not arise.

# Checklist:
- [✔️ ] My code follows the style guidelines of this project
- [ ✔️] I have performed a self-review of my code
- [✔️ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✔️ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [✔️ ] New and existing unit tests pass locally with my changes
- [✔️ ] Any dependent changes have been merged and published in downstream modules
