### PR TITLE
updated pull request to pull request target

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -3,7 +3,7 @@
 
 name: Deploy to Firebase Hosting on PR
 'on': 
-  pull_request:
+  pull_request_target:
     branches:
       - staging
 jobs:


### PR DESCRIPTION
The problem was described and solved here: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions.

The Dependabot has no access to the secrets.

Instead of: 'on': pull_request

Use: 'on': pull_request_target