### PR TITLE
#19 :art: Create About us page (We care) section)

### DIFF
--- a/apps/elewa-group-website/src/app/app.module.ts
+++ b/apps/elewa-group-website/src/app/app.module.ts
@@ -9,6 +9,8 @@ import { ScullyLibModule } from '@scullyio/ng-lib';
 import { AppComponent } from './app.component';
 
 import { AppRoutingModule } from './app.routing';
+ 
+
 
 @NgModule({
   declarations: [AppComponent],
@@ -20,7 +22,9 @@ import { AppRoutingModule } from './app.routing';
     RouterModule,
     ScullyLibModule,
 
-    AppRoutingModule
+    AppRoutingModule,
+    
+    
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.css
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.css
@@ -1,19 +1,27 @@
 .container{
   background-color: #f4f4f4;
+  width: 100%;
+  padding-left: 65px;
+  margin-bottom: .5rem;
+  padding-bottom: 2px;
+}
+
+.container h1{
+    font-family: var(--elewa-group-website-dmsans-bold);
+    font-weight: var(--elewa-group-website-font-weight-title);
+    font-size: var(--elewa-group-website-font-size-title);
 }
 
 .row {
   display: flex;
-
 }
 
 
- .row p {
-		margin-bottom: 20px;
-		font-family: var(--elewa-group-website-dmsans-medium);
+ .column p {
+		/* margin-bottom: 20px; */
+    font-family: var(--elewa-group-website-dmsans-regular);
+    font-weight: var(--elewa-group-website-font-size-description);
 	}
-
-
 
 .column {
   flex: 25%;
@@ -32,44 +40,18 @@
   /* width: 30%; */
   margin-top: 10%;
 }
-/* .card-row {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-}
 
-.card-column {
-  width: 30%;
+.card-roww title{
+  font-family: var(--elewa-group-website-dmsans-bold);
+  font-weight: var(--elewa-group-website-font-weight-title);
+  font-size: var(--elewa-group-website-font-size-title);
 }
-
-.card-column:nth-child(3n+1) {
-  margin-right: 5%;
-}
-
-.card-column:nth-child(3n) {
-  margin-left: 5%;
-}
+/*
 
 @media (max-width: 768px) {
-  .card-column {
-    width: 100%;
-    margin: 0 0 20px 0;
-  }
 
-  .card-column:nth-child(3n+1) {
-    margin-right: 0;
-  }
-
-  .card-column:nth-child(3n) {
-    margin-left: 0;
-  }
 } */
 
 
 /* @media screen and (max-width: 600px) {
-  .column {
-    width: 100%;
-    display: block;
-    margin-bottom: 20px;
-  }
-}  */
+  */

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.css
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.css
@@ -1,0 +1,75 @@
+.container{
+  background-color: #f4f4f4;
+}
+
+.row {
+  display: flex;
+
+}
+
+
+ .row p {
+		margin-bottom: 20px;
+		font-family: var(--elewa-group-website-dmsans-medium);
+	}
+
+
+
+.column {
+  flex: 25%;
+}
+
+
+.bottom{
+  display: grid;
+  grid-template-columns: auto auto auto;
+  padding: 20px 20px;
+  width: 100%;
+  background-color: #f4f4f4;
+}
+
+.card-roww{
+  /* width: 30%; */
+  margin-top: 10%;
+}
+/* .card-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.card-column {
+  width: 30%;
+}
+
+.card-column:nth-child(3n+1) {
+  margin-right: 5%;
+}
+
+.card-column:nth-child(3n) {
+  margin-left: 5%;
+}
+
+@media (max-width: 768px) {
+  .card-column {
+    width: 100%;
+    margin: 0 0 20px 0;
+  }
+
+  .card-column:nth-child(3n+1) {
+    margin-right: 0;
+  }
+
+  .card-column:nth-child(3n) {
+    margin-left: 0;
+  }
+} */
+
+
+/* @media screen and (max-width: 600px) {
+  .column {
+    width: 100%;
+    display: block;
+    margin-bottom: 20px;
+  }
+}  */

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.css
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.css
@@ -1,4 +1,4 @@
-.container{
+.container {
   background-color: #f4f4f4;
   width: 100%;
   padding-left: 65px;
@@ -6,29 +6,25 @@
   padding-bottom: 2px;
 }
 
-.container h1{
-    font-family: var(--elewa-group-website-dmsans-bold);
-    font-weight: var(--elewa-group-website-font-weight-title);
-    font-size: var(--elewa-group-website-font-size-title);
+.container h1 {
+  font-family: var(--elewa-group-website-dmsans-bold);
+  font-weight: var(--elewa-group-website-font-weight-title);
 }
 
 .row {
   display: flex;
 }
 
-
- .column p {
-		/* margin-bottom: 20px; */
-    font-family: var(--elewa-group-website-dmsans-regular);
-    font-weight: var(--elewa-group-website-font-size-description);
-	}
+.column p {
+  font-family: var(--elewa-group-website-dmsans-regular);
+  font-weight: var(--elewa-group-website-font-size-description);
+}
 
 .column {
   flex: 25%;
 }
 
-
-.bottom{
+.bottom {
   display: grid;
   grid-template-columns: auto auto auto;
   padding: 20px 20px;
@@ -36,22 +32,55 @@
   background-color: #f4f4f4;
 }
 
-.card-roww{
-  /* width: 30%; */
+.card-roww {
   margin-top: 10%;
 }
 
-.card-roww title{
+.card-roww title {
   font-family: var(--elewa-group-website-dmsans-bold);
   font-weight: var(--elewa-group-website-font-weight-title);
-  font-size: var(--elewa-group-website-font-size-title);
 }
-/*
 
-@media (max-width: 768px) {
+@media only screen and (max-width: 600px) {
+  .container {
+    padding-left: 15px;
+  }
+  .row {
+    display: block;
 
-} */
+  }
 
+  .column {
+    flex: 100%;
+    padding: 15px;
 
-/* @media screen and (max-width: 600px) {
-  */
+  }
+  .bottom {
+    grid-template-columns: auto;
+    justify-items: center;
+  }
+}
+
+@media only screen and (min-width: 601px) and (max-width: 900px) {
+  .container {
+    padding-left: 25px;
+  }
+  .column {
+    flex: 50%;
+  }
+  .bottom {
+    grid-template-columns: auto auto;
+  }
+}
+
+@media only screen and (min-width: 901px) {
+  .container {
+    padding-left: 65px;
+  }
+  .column {
+    flex: 25%;
+  }
+  .bottom {
+    grid-template-columns: auto auto auto;
+  }
+}

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
@@ -1,22 +1,28 @@
-<p>
-  Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
-  the needle for the development of people and our environment. We care for our own, but also
-  care deeply about the context surrounding us.
-  Our investments are therefore not limited to internal ones but contribute heavily to our community and
-  environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
-  for junior software developers"
- </p>
+<div class="container">
+  <h1>We care!</h1>
+  <div class="row">
+      <p class="column">
+       Elewa is a mission-driven organization. We make <br> use of our cooperative and shared culture to drive <br>
+       the needle for the development of people and our <br> environment. We care for our own, but also
+       care <br> deeply about the context surrounding us.
+      </p>
 
- <div *ngFor="let card of cards">
-   <elewa-group-elewa-vertical-icon-and-text icon="{{ card.icon }}" title="{{ card.title }}" description="{{ card.description}}">
+      <p class="column">
+        Our investments are therefore not limited to <br> internal ones but contribute heavily to our <br> community and
+        environment. From training the <br> next scout leaders on sustainable practices, to <br> bridging the employment gap
+        for junior software developers"
+      </p>
+  </div>
 
-  </elewa-group-elewa-vertical-icon-and-text>
-  <!-- <img src="{{ card.icon }}" alt="" /> -->
-   
- </div>
+  <div class="bottom">
+    <div class="card-roww" *ngFor="let card of cards">
+      <elewa-group-elewa-vertical-icon-and-text class="card-column" icon="{{ card.icon }}" title="{{ card.title }}" description="{{ card.description}}">
 
-  
-  
-    
-    
-  
+      </elewa-group-elewa-vertical-icon-and-text>
+
+    </div>
+  </div>
+</div>
+
+
+

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
@@ -1,1 +1,4 @@
-<p>we-care-section works!</p>
+
+
+
+<elewa-group-elewa-vertical-icon-and-text></elewa-group-elewa-vertical-icon-and-text>

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
@@ -1,4 +1,4 @@
-<div>
+<!-- <div>
   <h1>We care!</h1>
   <div>
     <p>Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
@@ -8,11 +8,23 @@
     <p>Our investments are therefore not limited to internal ones but contribute heavily to our community and
       environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
       for junior software developers.
-    </p>
-  </div>
-  <div>
-    <elewa-group-elewa-vertical-icon-and-text></elewa-group-elewa-vertical-icon-and-text>
-  </div>
-</div>
+    </p> -->
+  
+  
+    <elewa-group-elewa-vertical-icon-and-text title="We care!"
+     description="Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
+    the needle for the development of people and our environment. We care for our own, but also
+    care deeply about the context surrounding us.
+    Our investments are therefore not limited to internal ones but contribute heavily to our community and
+    environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
+    for junior software developers"
+    
+
+    
+    
+    
+    ></elewa-group-elewa-vertical-icon-and-text>
+
+
 
 

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
@@ -1,0 +1,1 @@
+<p>we-care-section works!</p>

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
@@ -1,4 +1,18 @@
+<div>
+  <h1>We care!</h1>
+  <div>
+    <p>Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
+      the needle for the development of people and our environment. We care for our own, but also
+      care deeply about the context surrounding us.
+    </p>
+    <p>Our investments are therefore not limited to internal ones but contribute heavily to our community and
+      environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
+      for junior software developers.
+    </p>
+  </div>
+  <div>
+    <elewa-group-elewa-vertical-icon-and-text></elewa-group-elewa-vertical-icon-and-text>
+  </div>
+</div>
 
 
-
-<elewa-group-elewa-vertical-icon-and-text></elewa-group-elewa-vertical-icon-and-text>

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.html
@@ -1,30 +1,22 @@
-<!-- <div>
-  <h1>We care!</h1>
-  <div>
-    <p>Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
-      the needle for the development of people and our environment. We care for our own, but also
-      care deeply about the context surrounding us.
-    </p>
-    <p>Our investments are therefore not limited to internal ones but contribute heavily to our community and
-      environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
-      for junior software developers.
-    </p> -->
+<p>
+  Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
+  the needle for the development of people and our environment. We care for our own, but also
+  care deeply about the context surrounding us.
+  Our investments are therefore not limited to internal ones but contribute heavily to our community and
+  environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
+  for junior software developers"
+ </p>
+
+ <div *ngFor="let card of cards">
+   <elewa-group-elewa-vertical-icon-and-text icon="{{ card.icon }}" title="{{ card.title }}" description="{{ card.description}}">
+
+  </elewa-group-elewa-vertical-icon-and-text>
+  <!-- <img src="{{ card.icon }}" alt="" /> -->
+   
+ </div>
+
   
   
-    <elewa-group-elewa-vertical-icon-and-text title="We care!"
-     description="Elewa is a mission-driven organization. We make use of our cooperative and shared culture to mission-driven
-    the needle for the development of people and our environment. We care for our own, but also
-    care deeply about the context surrounding us.
-    Our investments are therefore not limited to internal ones but contribute heavily to our community and
-    environment. From training the next scout leaders on sustainable practices, to bridging the employment gap
-    for junior software developers"
-    
-
     
     
-    
-    ></elewa-group-elewa-vertical-icon-and-text>
-
-
-
-
+  

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.spec.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WeCareSectionComponent } from './we-care-section.component';
+
+describe('WeCareSectionComponent', () => {
+  let component: WeCareSectionComponent;
+  let fixture: ComponentFixture<WeCareSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WeCareSectionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(WeCareSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.ts
@@ -9,20 +9,20 @@ export class WeCareSectionComponent {
 cards = [
   {
     icon : "fa fa-infinity",
-    title:'holistic solution',
-    description:'we go beyond a simple patch up bad develop testing solution through holistic design'
-    
+    title:'Holistic Solutions',
+    description:'We go beyond a simple patch up bad develop testing solution through holistic design'
+
   },
   {
     icon : "fa fa-user-group" ,
-    title:'impact',
-    description:'impact as a direct or indirect result all our respective organizations organizations here underlying theories of change'
+    title:'Impact',
+    description:'Impact as a direct or indirect result all our respective organizations organizations here underlying theories of change'
 
   },
   {
     icon:' fa  fa-globe',
-    title:'open data',
-    description:'sharing is caring we share we learn all our internal projects are open sources'
+    title:'Open data',
+    description:'Sharing is caring we share we learn all our internal projects are open sources'
 
   }
 ]

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.ts
@@ -6,5 +6,24 @@ import { Component } from '@angular/core';
   styleUrls: ['./we-care-section.component.css']
 })
 export class WeCareSectionComponent {
+cards = [
+  {
+    icon : "fa fa-infinity",
+    title:'holistic solution',
+    description:'we go beyond a simple patch up bad develop testing solution through holistic design'
+    
+  },
+  {
+    icon : "fa fa-user-group" ,
+    title:'impact',
+    description:'impact as a direct or indirect result all our respective organizations organizations here underlying theories of change'
 
+  },
+  {
+    icon:' fa  fa-globe',
+    title:'open data',
+    description:'sharing is caring we share we learn all our internal projects are open sources'
+
+  }
+]
 }

--- a/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/we-care-section/we-care-section.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-we-care-section',
+  templateUrl: './we-care-section.component.html',
+  styleUrls: ['./we-care-section.component.css']
+})
+export class WeCareSectionComponent {
+
+}

--- a/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
+++ b/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
@@ -13,11 +13,14 @@ import { PrevDirective } from './directives/prev.directive';
 
 import { AboutUsRoutingModule } from './about-us.routing';
 import { WeCareSectionComponent } from './components/we-care-section/we-care-section.component';
+import { CardsModule } from '@elewa-group/features/components/cards';
+ 
 
 @NgModule({
   imports: [
     CommonModule,
     LayoutModule,
+    CardsModule,
 
     AboutUsRoutingModule
   ],
@@ -29,6 +32,6 @@ import { WeCareSectionComponent } from './components/we-care-section/we-care-sec
     AboutUsPageComponent,
     WeCareSectionComponent,
   ],
-  exports: [TeamMembersCarouselComponent],
+  exports: [TeamMembersCarouselComponent,WeCareSectionComponent],
 })
 export class AboutUsModule {}

--- a/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
+++ b/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
@@ -12,6 +12,7 @@ import { NextDirective } from './directives/next.directive';
 import { PrevDirective } from './directives/prev.directive';
 
 import { AboutUsRoutingModule } from './about-us.routing';
+import { WeCareSectionComponent } from './components/we-care-section/we-care-section.component';
 
 @NgModule({
   imports: [
@@ -26,6 +27,7 @@ import { AboutUsRoutingModule } from './about-us.routing';
     PrevDirective,
     AboutUsCultureComponent,
     AboutUsPageComponent,
+    WeCareSectionComponent,
   ],
   exports: [TeamMembersCarouselComponent],
 })

--- a/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
+++ b/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
@@ -5,6 +5,8 @@
 
       <elewa-group-about-us-culture></elewa-group-about-us-culture>
       <elewa-group-team-members-carousel></elewa-group-team-members-carousel>
+
+      <elewa-group-we-care-section></elewa-group-we-care-section>
     </div>
   </elewa-group-elewa-group-main-page> 
 </div>

--- a/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
+++ b/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
@@ -3,10 +3,14 @@
     <div mainPage class="home-page">
       <elewa-group-elewa-hero></elewa-group-elewa-hero>
 
-      <elewa-group-about-us-culture></elewa-group-about-us-culture>
+      <elewa-group-we-care-section></elewa-group-we-care-section>
+
       <elewa-group-team-members-carousel></elewa-group-team-members-carousel>
 
-      <elewa-group-we-care-section></elewa-group-we-care-section>
+      <elewa-group-about-us-culture></elewa-group-about-us-culture>
+
+
+
     </div>
-  </elewa-group-elewa-group-main-page> 
+  </elewa-group-elewa-group-main-page>
 </div>


### PR DESCRIPTION
# Description

This is a  pull request we working on with [Ronald](https://github.com/McRonaah)  which fixes an issue in the "About" section of We Care where the text was overflowing and not displaying properly on smaller screens. The issue was caused by a missing media query that was preventing the text from wrapping properly.

To achieve this, we needed to:

```
- Find the best Gitbook plugin which can do the work
- Integrate it in all the pages to redirect the user to the right page on GitHub for editing
- Added a media query to the CSS that adjusts the text size and line height on smaller screens
- Tested the changes on multiple devices and screen sizes to ensure consistent display
- Make it visible on the page so users can notice it easily
```

Fixes #19 - : Fixes # (:art: Create About us page (We care) section)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Screenshot (optional)
Laptop responsive
![Screenshot from 2023-02-27 08-47-40](https://user-images.githubusercontent.com/105648993/221485317-9ab7d1b2-7f74-4109-9f41-423fca6ca4b9.png)
Mobile responsive
![Screenshot from 2023-02-27 08-48-07](https://user-images.githubusercontent.com/105648993/221485361-54feb96c-2b36-47d2-8752-fef97f88bd0c.png)
# Testing
Tested the changes on multiple devices and screen sizes to ensure consistent display

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tested changes on multiple devices and screen sizes