### PR TITLE
#244 / Reusable Key Figure Card Component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -5,6 +5,7 @@
     "elewa-group-website": "apps/elewa-group-website",
     "features-components-banners": "libs/features/components/banners",
     "features-components-ui-lists": "libs/features/components/ui-lists",
+    "features-components-cards": "libs/features/components/cards",
     "pages-elewa-about-us": "libs/pages/elewa/about-us",
     "pages-elewa-activities": "libs/pages/elewa/activities",
     "pages-elewa-contact": "libs/pages/elewa/contact",

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.css
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.css
@@ -1,0 +1,37 @@
+.card{
+    padding: 20px 30px;
+    font-family: var( --elewa-group-website-dmsans-regular);
+    border: 1px solid var(--elewa-group-website-color-card-item3);
+    border-radius: 20px;
+    width: 300px;
+    height: 300px;
+}
+
+.img{
+    align-items: center;
+    padding-top: 40%;
+}
+
+.fig{
+    font-family: var(--elewa-group-website-dmsans-bold);
+    font-weight: var(--elewa-group-website-font-weight-title-medium);
+    font-size: var(--elewa-group-website-font-size-title);
+    text-align: center;
+    padding-top: 40%;
+}
+
+.text{
+    font-weight: var(--elewa-group-website-font-size-description);
+    font-family: var(--elewa-group-website-dmsans-regular);
+    text-align: center;
+    padding-top: 10%;
+}
+
+@media only screen and (max-width: 850px) {
+    .card{
+        width: 300px;
+        border-radius: 23px;
+        padding: 20px 25px;
+        height: 320px;
+    }
+}

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
@@ -1,12 +1,9 @@
 <!-- <p>elewa-key-figure-card works!</p> -->
 <div class="card">
     <div class="details">
-        <p class="fig">{{figure}}</p>
-        <p class="text">{{description}}</p>
+        <div class="img" isImage >
+            <img class="fig">{{figure}}<img>
+            <p class="text">{{description}}</p>
+        </div>
     </div>
-
-</div>
-
-<div class="card">
-    <img class="img" src={{isImage}} alt="">
 </div>

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.html
@@ -1,0 +1,12 @@
+<!-- <p>elewa-key-figure-card works!</p> -->
+<div class="card">
+    <div class="details">
+        <p class="fig">{{figure}}</p>
+        <p class="text">{{description}}</p>
+    </div>
+
+</div>
+
+<div class="card">
+    <img class="img" src={{isImage}} alt="">
+</div>

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.spec.ts
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaKeyFigureCardComponent } from './elewa-key-figure-card.component';
+
+describe('ElewaKeyFigureCardComponent', () => {
+  let component: ElewaKeyFigureCardComponent;
+  let fixture: ComponentFixture<ElewaKeyFigureCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ElewaKeyFigureCardComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ElewaKeyFigureCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
@@ -6,11 +6,8 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./elewa-key-figure-card.component.css']
 })
 export class ElewaKeyFigureCardComponent {
-  @Input() figure = '10M';
-  @Input() description = 'Number of unfilled technical vancancies in US and EU markets';
-  @Input() isImage = 'https://i.postimg.cc/wxnQLbYY/nextsteps.png';
-  // @Input() figure? : string;
-  // @Input() description? : string;
-  // @Input() isImage? : boolean;
+  @Input() figure? : string;
+  @Input() description? : string;
+  @Input() isImage? : boolean;
   
 }

--- a/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
+++ b/libs/features/components/cards/src/lib/cards/elewa-key-figure-card/elewa-key-figure-card.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-key-figure-card',
+  templateUrl: './elewa-key-figure-card.component.html',
+  styleUrls: ['./elewa-key-figure-card.component.css']
+})
+export class ElewaKeyFigureCardComponent {
+  @Input() figure = '10M';
+  @Input() description = 'Number of unfilled technical vancancies in US and EU markets';
+  @Input() isImage = 'https://i.postimg.cc/wxnQLbYY/nextsteps.png';
+  // @Input() figure? : string;
+  // @Input() description? : string;
+  // @Input() isImage? : boolean;
+  
+}

--- a/libs/features/components/cards/src/lib/features-components-cards.module.ts
+++ b/libs/features/components/cards/src/lib/features-components-cards.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ElewaGroupCardComponent } from './cards/elewa-group-card/elewa-group-card.component';
-import { ElewaVerticalIconAndTextComponent } from './cards/elewa-vertical-icon-and-text/elewa-vertical-icon-and-text.component'
+import { ElewaVerticalIconAndTextComponent } from './cards/elewa-vertical-icon-and-text/elewa-vertical-icon-and-text.component';
+import { ElewaKeyFigureCardComponent } from './cards/elewa-key-figure-card/elewa-key-figure-card.component'
 
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent],
-  exports: [ ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent]
+  declarations: [ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent, ElewaKeyFigureCardComponent],
+  exports: [ ElewaGroupCardComponent, ElewaVerticalIconAndTextComponent, ElewaKeyFigureCardComponent]
 })
 export class CardsModule {}


### PR DESCRIPTION
# Description

* Worked on this with @Calvin-Ngugi 

This section contains a type of card that is used to show various metrics.
The top part can show either Key Figure or logo Image.

The card shows the following inputs:
```
1. Figure (string)
2. Description (string) which is optional
3. isImage (boolean)
```

To achieve this, we needed to:

```
- Export the component for re-usability
- Make it visible on the page so users can notice it easily
```

Fixes # (issue) - *Example*: Fixes # ([S4Y-400](https://www.w3.org/Provider/Style/dummy.html), [S4Y-100](https://www.w3.org/Provider/Style/dummy.html))

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Screenshot 
![Screenshot from 2023-02-27 10-14-52](https://user-images.githubusercontent.com/53012069/221500583-01d1bc69-c036-4108-a18a-5a32cce5918c.png)

Responsiveness

![Screenshot from 2023-02-27 10-15-17](https://user-images.githubusercontent.com/53012069/221500663-c037bc4c-03ff-4c5d-9caa-de384d042500.png)


# How Has This Been Tested?
Tested by rendering different inputs. 

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
