### PR TITLE
Issue311/ft careers module and routing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -8,6 +8,7 @@
     "features-components-ui-lists": "libs/features/components/ui-lists",
     "pages-elewa-about-us": "libs/pages/elewa/about-us",
     "pages-elewa-activities": "libs/pages/elewa/activities",
+    "pages-elewa-careers": "libs/pages/elewa/careers",
     "pages-elewa-contact": "libs/pages/elewa/contact",
     "pages-elewa-home": "libs/pages/elewa/home",
     "pages-elewa-invest": "libs/pages/elewa/invest",

--- a/libs/elements/layout/src/lib/components/header/header.component.html
+++ b/libs/elements/layout/src/lib/components/header/header.component.html
@@ -23,6 +23,9 @@
           <li class="nav-items">
             <a class="nav-link" routerLink="/contact/en" routerLinkActive="active" ariaCurrentWhenActive="page">Contact</a>
           </li>
+          <li class="nav-items">
+            <a class="nav-link" routerLink="/careers/en" routerLinkActive="active" ariaCurrentWhenActive="page">Careers</a>
+          </li>
       </ul>
       <div class="hamburger">
         <span class="bar"></span>
@@ -55,6 +58,9 @@
             </li>
             <li class="nav-item one">
               <a class="nav-link" routerLink="/contact/en" routerLinkActive="active" ariaCurrentWhenActive="page">Contact</a>
+            </li>
+            <li class="nav-items">
+              <a class="nav-link" routerLink="/careers/en" routerLinkActive="active" ariaCurrentWhenActive="page">Careers</a>
             </li>
         </ul>
       </div>

--- a/libs/pages/elewa/careers/.eslintrc.json
+++ b/libs/pages/elewa/careers/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaGroup",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-group",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/pages/elewa/careers/README.md
+++ b/libs/pages/elewa/careers/README.md
@@ -1,0 +1,7 @@
+# pages-elewa-careers
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test pages-elewa-careers` to execute the unit tests.

--- a/libs/pages/elewa/careers/jest.config.ts
+++ b/libs/pages/elewa/careers/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'pages-elewa-careers',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../../coverage/libs/pages/elewa/careers',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/pages/elewa/careers/project.json
+++ b/libs/pages/elewa/careers/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "pages-elewa-careers",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/pages/elewa/careers/src",
+  "prefix": "elewa-group",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/pages/elewa/careers/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/pages/elewa/careers/**/*.ts",
+          "libs/pages/elewa/careers/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/pages/elewa/careers/src/index.ts
+++ b/libs/pages/elewa/careers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/pages-elewa-careers.module';

--- a/libs/pages/elewa/careers/src/lib/careers.routing.ts
+++ b/libs/pages/elewa/careers/src/lib/careers.routing.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Route } from '@angular/router';
+
+import { CareersPageComponent } from './pages/careers-page/careers-page.component';
+
+export const ELEWA_CAREERS_ROUTES: Route[] = [
+
+
+ { path: '', component: CareersPageComponent },
+
+
+];
+@NgModule({
+ imports: [RouterModule.forChild(ELEWA_CAREERS_ROUTES)],
+ exports: [RouterModule]
+})
+export class CareersRoutingModule { }

--- a/libs/pages/elewa/careers/src/lib/pages-elewa-careers.module.ts
+++ b/libs/pages/elewa/careers/src/lib/pages-elewa-careers.module.ts
@@ -1,9 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { LayoutModule } from '@elewa-group/elements/layout';
+import { BannersModule } from '@elewa-group/features/components/banners';
 import { CareersPageComponent } from './pages/careers-page/careers-page.component';
 
+import { CareersRoutingModule } from './careers.routing';
+
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, LayoutModule, BannersModule, CareersRoutingModule],
   declarations: [CareersPageComponent],
 })
 export class PagesElewaCareersModule {}

--- a/libs/pages/elewa/careers/src/lib/pages-elewa-careers.module.ts
+++ b/libs/pages/elewa/careers/src/lib/pages-elewa-careers.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class PagesElewaCareersModule {}

--- a/libs/pages/elewa/careers/src/lib/pages-elewa-careers.module.ts
+++ b/libs/pages/elewa/careers/src/lib/pages-elewa-careers.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CareersPageComponent } from './pages/careers-page/careers-page.component';
 
 @NgModule({
   imports: [CommonModule],
+  declarations: [CareersPageComponent],
 })
 export class PagesElewaCareersModule {}

--- a/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.html
+++ b/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.html
@@ -1,0 +1,1 @@
+<p>careers-page works!</p>

--- a/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.html
+++ b/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.html
@@ -1,1 +1,5 @@
-<p>careers-page works!</p>
+<div>
+  <elewa-group-elewa-group-main-page>
+    <div mainPage class="home-page"></div>
+  </elewa-group-elewa-group-main-page>
+</div>

--- a/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.spec.ts
+++ b/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CareersPageComponent } from './careers-page.component';
+
+describe('CareersPageComponent', () => {
+  let component: CareersPageComponent;
+  let fixture: ComponentFixture<CareersPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CareersPageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CareersPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.ts
+++ b/libs/pages/elewa/careers/src/lib/pages/careers-page/careers-page.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-careers-page',
+  templateUrl: './careers-page.component.html',
+  styleUrls: ['./careers-page.component.scss'],
+})
+export class CareersPageComponent {}

--- a/libs/pages/elewa/careers/src/test-setup.ts
+++ b/libs/pages/elewa/careers/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/pages/elewa/careers/tsconfig.json
+++ b/libs/pages/elewa/careers/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/pages/elewa/careers/tsconfig.lib.json
+++ b/libs/pages/elewa/careers/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test-setup.ts",
+    "src/**/*.spec.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/pages/elewa/careers/tsconfig.spec.json
+++ b/libs/pages/elewa/careers/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,9 @@
       "@elewa-group/pages/elewa/activities": [
         "libs/pages/elewa/activities/src/index.ts"
       ],
+      "@elewa-group/pages/elewa/careers": [
+        "libs/pages/elewa/careers/src/index.ts"
+      ],
       "@elewa-group/pages/elewa/contact": [
         "libs/pages/elewa/contact/src/index.ts"
       ],


### PR DESCRIPTION
# Description

A careers page that contains the open positions for the organisation


Create the lib and setup routing to it.
Add a routing file "careers.routing.ts"
Add the main page for this lib "elewa-careers-page" (inside a pages folder)
Add a careers tab on the header and it's routerLink

Add the elewa-main-page template to the elewa-careers-page

https://github.com/italanta/elewa-group/issues/311

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)

![careersMobile](https://user-images.githubusercontent.com/109944021/221532443-eef6d430-e43b-4414-9ff7-0e206fcacc69.png)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 


# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
