### PR TITLE
Issue 321/ft reusable brand banner

### DIFF
--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.html
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.html
@@ -1,0 +1,1 @@
+<p>elewa-group-brands works!</p>

--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.html
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.html
@@ -1,1 +1,16 @@
-<p>elewa-group-brands works!</p>
+<div id="brands__banner">
+    <div class="container {{logoPlacement}}">
+        <div id="text-content" class="content">
+            <h1 class="title">{{name}}</h1>
+            <p class="paragraph" >{{brandDescription}}</p>
+            <div>
+                <elewa-group-button-with-animation [message]="buttonText" [action]="url"></elewa-group-button-with-animation>
+            </div>
+            <hr>
+        </div>
+        <div id="img-content" class="content">
+            <img [src]="logo"/>
+        </div>
+    </div>
+    <hr>
+</div>

--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.scss
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.scss
@@ -1,0 +1,116 @@
+#brands__banner {
+    width: 100vw;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    font-size: var(--elewa-group-website-font-size-elewa-text);
+    font-family: var(--elewa-group-website-dmsans-regular);
+    border-bottom-left-radius: 30px;
+    border-bottom-right-radius: 30px;
+}
+
+#brands__banner .container {
+    display: flex;
+    gap: 10%;
+    width: 80%;
+    max-height: 80vh;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 50px;
+    border-bottom: 2px solid gray;
+}
+
+#brands__banner .container.left {
+    flex-direction: row-reverse;
+}
+
+#brands__banner .content {
+    display: grid;
+    place-items: center;
+}
+
+#brands__banner #text-content,
+#brands__banner .content img {
+    max-height: max(80vh, 600px);
+    max-width: 60vw;
+    object-fit: cover;
+}
+
+#brands__banner #text-content {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    width: 60%;
+}
+
+#brands__banner #text-content .title {
+    margin-bottom: 2rem;
+}
+
+#brands__banner #text-content .paragraph {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+#brands__banner .content#img-content img {
+    border-radius: 2rem;
+}
+
+
+// RESPONSIVENESS
+$breakpoint-tablet: 768px;
+$breakpoint-low-res-desktops: 1360px;
+
+@media (max-width: $breakpoint-low-res-desktops){
+    #brands__banner {
+        border-bottom-left-radius: 20px;
+        border-bottom-right-radius: 20px;
+    }
+
+    #brands__banner {
+        font-size: var(--elewa-group-website-font-size-elewa-text-medium);
+    }
+
+    #brands__banner .container {
+        gap: 5%;
+        width: 90%;
+        max-height: 80vh;
+    }
+}
+
+hr{
+    border: 2px solid gray;
+}
+@media (max-width: $breakpoint-tablet), (max-aspect-ratio: 1.1) {
+    #brands__banner {
+        font-size: var(--elewa-group-website-font-size-elewa-text-medium);
+        font-family: var(--elewa-group-website-dmsans-regular);
+    }
+
+    #brands__banner .container {
+        flex-direction: column;
+        max-height: none;
+        justify-content: space-around;
+    }
+
+    #brands__banner #text-content,
+    #brands__banner .content img {
+        width: calc(min(90vw, 480px) - 3rem);
+        max-width: none;
+        max-height: none;
+        margin-top: 2.5rem;
+        margin-bottom: 2.5rem;
+    }
+
+    #brands__banner #text-content .title {
+        margin-bottom: 1rem;
+    }
+
+    #brands__banner .container.left {
+        flex-direction: column-reverse;
+    }
+
+    #brands__banner .content#img-content img {
+        border-radius: 1.2rem;
+    }
+}

--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.spec.ts
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaGroupBrandsComponent } from './elewa-group-brands.component';
+
+describe('ElewaGroupBrandsComponent', () => {
+  let component: ElewaGroupBrandsComponent;
+  let fixture: ComponentFixture<ElewaGroupBrandsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaGroupBrandsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaGroupBrandsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.ts
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.ts
@@ -1,8 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'elewa-group-elewa-group-brands',
   templateUrl: './elewa-group-brands.component.html',
   styleUrls: ['./elewa-group-brands.component.scss'],
 })
-export class ElewaGroupBrandsComponent {}
+export class ElewaGroupBrandsComponent {
+
+  @Input () logo: string;
+  @Input () name: string;
+  @Input () brandDescription: string
+  @Input () buttonText: string
+  @Input () logoPlacement: string
+}

--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.ts
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.ts
@@ -11,5 +11,6 @@ export class ElewaGroupBrandsComponent {
   @Input () name: string;
   @Input () brandDescription: string
   @Input () buttonText: string
+  @Input() url = '';
   @Input () logoPlacement: string
 }

--- a/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.ts
+++ b/libs/features/components/banners/src/lib/banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-group-brands',
+  templateUrl: './elewa-group-brands.component.html',
+  styleUrls: ['./elewa-group-brands.component.scss'],
+})
+export class ElewaGroupBrandsComponent {}

--- a/libs/features/components/banners/src/lib/features-components-banners.module.ts
+++ b/libs/features/components/banners/src/lib/features-components-banners.module.ts
@@ -1,29 +1,26 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router'
+import { RouterModule } from '@angular/router';
 
 import { ButtonsModule } from '@elewa-group/features/components/buttons';
 
 import { ElewaGroupImageAndTextBannerComponent } from './banners/elewa-group-image-and-text-banner/elewa-group-image-and-text-banner.component';
 import { ElewaGroupTeamMemberComponent } from './banners/elewa-group-team-member/elewa-group-team-member.component';
 import { ElewaCallToActionBannerComponent } from './banners/elewa-call-to-action-banner/elewa-call-to-action-banner.component';
+import { ElewaGroupBrandsComponent } from './banners/elewa-group-brands/elewa-group-brands/elewa-group-brands.component';
 
 @NgModule({
-
-  imports: [
-    CommonModule, 
-    ButtonsModule, 
-    RouterModule
-  ],
+  imports: [CommonModule, ButtonsModule, RouterModule],
   declarations: [
     ElewaGroupTeamMemberComponent,
     ElewaGroupImageAndTextBannerComponent,
-    ElewaCallToActionBannerComponent
+    ElewaCallToActionBannerComponent,
+    ElewaGroupBrandsComponent,
   ],
   exports: [
     ElewaGroupTeamMemberComponent,
     ElewaGroupImageAndTextBannerComponent,
-    ElewaCallToActionBannerComponent
+    ElewaCallToActionBannerComponent,
   ],
 })
 export class BannersModule {}

--- a/libs/features/components/banners/src/lib/features-components-banners.module.ts
+++ b/libs/features/components/banners/src/lib/features-components-banners.module.ts
@@ -21,6 +21,7 @@ import { ElewaGroupBrandsComponent } from './banners/elewa-group-brands/elewa-gr
     ElewaGroupTeamMemberComponent,
     ElewaGroupImageAndTextBannerComponent,
     ElewaCallToActionBannerComponent,
+    ElewaGroupBrandsComponent
   ],
 })
 export class BannersModule {}


### PR DESCRIPTION
# Description

We need a brands banner to showcase the brands we are working with

To do this, we need to: 
```
- Make it visible on the page so users can notice it easily
- Make a reusable brands banner component
```

Fixes https://github.com/italanta/elewa-group/issues/321

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)



# Screenshot (optional)

![brandBannersLeft](https://user-images.githubusercontent.com/109944021/221569273-e5bab8c2-4dea-4c66-8f9c-84c13bf5a44f.png)



![brandBannerRight](https://user-images.githubusercontent.com/109944021/221569298-6b956eda-fe72-487b-8e1e-239211b47523.png)



# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
