### PR TITLE
#19 Create About us page (We care) section

### DIFF
--- a/libs/features/components/cards/src/lib/cards/elewa-vertical-icon-and-text/elewa-vertical-icon-and-text.component.html
+++ b/libs/features/components/cards/src/lib/cards/elewa-vertical-icon-and-text/elewa-vertical-icon-and-text.component.html
@@ -1,5 +1,6 @@
 <div class="about-card">
   <i class="{{ icon }} about-icon"></i>
+  <img [src]="icon" class="about-icon"/>
   <h3 class="about-title">{{ title }}</h3>
   <p class="about-description">{{ description }}</p>
 </div>

--- a/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.html
+++ b/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.html
@@ -1,0 +1,17 @@
+
+<div class="container">
+    <h2>{{ title }}</h2>
+    <div class="paragraphs">
+      <p class="paragraph">{{ paragraph1 }}</p>
+      <p class="paragraph">{{ paragraph2 }}</p>
+    </div>
+    <div class="iconcol">
+      <elewa-group-elewa-vertical-icon-and-text
+        *ngFor="let column of columns"
+        [icon]="column.icon"
+        [title]="column.title"
+        [description]="column.description"
+      >
+      </elewa-group-elewa-vertical-icon-and-text>
+    </div>
+  </div>

--- a/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.scss
+++ b/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.scss
@@ -7,13 +7,13 @@
     font-size: var(--elewa-group-website-team-and-members-h1-font-size);
     padding-left: 90px;
     padding-top: 80px;
+    
 }
 .paragraphs{
     display: flex;
     padding-top: 20px;
     justify-content: space-evenly;
     font-family: var(--elewa-group-website-dmsans-regular);
-    font-family:  var(--elewa-group-website-dmsans-regular);
     font-size: var( --elewa-group-website-timeline-description);
 }
 .paragraph{
@@ -29,16 +29,24 @@
 }
 
 @media (max-width: 768px) {
+    .container h2{
+        padding-left: 40px;
+       
+    }
     .iconcol {
       flex-direction: column;
       align-items: stretch;
+      margin: 10px;
+      padding-top:70px;
     }
 
     .paragraphs {
          flex-direction: column;
-         margin: 35px;
+         margin: auto;
+         width: 80%;
+        
     }
     p:nth-child(1){
-            margin-bottom: 30px;
+      margin-bottom: 20px;
     }
 }

--- a/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.scss
+++ b/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.scss
@@ -1,0 +1,44 @@
+.container{ 
+    border-radius: 0 0 30px 30px;
+    background-color: var(--elewa-group-website-color-card);
+}
+
+.container h2{
+    font-size: var(--elewa-group-website-team-and-members-h1-font-size);
+    padding-left: 90px;
+    padding-top: 80px;
+}
+.paragraphs{
+    display: flex;
+    padding-top: 20px;
+    justify-content: space-evenly;
+    font-family: var(--elewa-group-website-dmsans-regular);
+    font-family:  var(--elewa-group-website-dmsans-regular);
+    font-size: var( --elewa-group-website-timeline-description);
+}
+.paragraph{
+    flex-basis: 38%;
+}
+.iconcol{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 50px;
+    padding-bottom: 100px;
+   
+}
+
+@media (max-width: 768px) {
+    .iconcol {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .paragraphs {
+         flex-direction: column;
+         margin: 35px;
+    }
+    p:nth-child(1){
+            margin-bottom: 30px;
+    }
+}

--- a/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.spec.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AboutUsWeCareComponent } from './about-us-we-care.component';
+
+describe('AboutUsWeCareComponent', () => {
+  let component: AboutUsWeCareComponent;
+  let fixture: ComponentFixture<AboutUsWeCareComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AboutUsWeCareComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AboutUsWeCareComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-about-us-we-care',
+  templateUrl: './about-us-we-care.component.html',
+  styleUrls: ['./about-us-we-care.component.scss'],
+})
+export class AboutUsWeCareComponent {
+  @Input() title = "We Care"
+  @Input() paragraph1 = "Elewa is a mission-driven organization. We make use of our cooperative and shared culture to drive the needle for the development of people and our environment.We care for our own, but also care deeply about the context surrounding us."
+  @Input() paragraph2 = " Our investments are therefore not limited to internal ones but contribure heavily to our community and environment.From training the next scout leaders on sustainable practices, to bridging the employment gap for junior software developers."
+  columns = [
+    {
+      icon: "https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690300/elewa-group-website/Icons/PNG/Holistic_id4kra.png",
+      title: "Holistic solutions",
+      description: "We go beyond a simple patch-up but develop lasting solutions through holistic design."
+    },
+    {
+      icon:"https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Icons/PNG/coorperative_kzlzrg.png",
+      title: "Impact",
+      description: "Impact as a direct, or indirect, result. All our respective organizations have underlying theories of change."
+    },    {
+      icon: "https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690301/elewa-group-website/Icons/PNG/ownership_yno4a2.png",
+      title: "Open data",
+      description: "Sharing is caring. We share what we learn. All our internal projects are open source."
+    },
+  ]
+
+}

--- a/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.ts
+++ b/libs/pages/elewa/about-us/src/lib/components/about-us-we-care/about-us-we-care.component.ts
@@ -6,7 +6,7 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./about-us-we-care.component.scss'],
 })
 export class AboutUsWeCareComponent {
-  @Input() title = "We Care"
+  @Input() title = "We Care!"
   @Input() paragraph1 = "Elewa is a mission-driven organization. We make use of our cooperative and shared culture to drive the needle for the development of people and our environment.We care for our own, but also care deeply about the context surrounding us."
   @Input() paragraph2 = " Our investments are therefore not limited to internal ones but contribure heavily to our community and environment.From training the next scout leaders on sustainable practices, to bridging the employment gap for junior software developers."
   columns = [

--- a/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
+++ b/libs/pages/elewa/about-us/src/lib/elewa-about-us.module.ts
@@ -2,14 +2,13 @@ import { NgModule } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
 
-
 import { UiListsModule } from '@elewa-group/features/components/ui-lists';
 
 import { ElewaAboutUsLocationSectionComponent } from './components/elewa-about-us-location-section/elewa-about-us-location-section.component';
 
-import { GoogleMapsModule } from '@angular/google-maps'
+import { GoogleMapsModule } from '@angular/google-maps';
 
-import { ButtonsModule } from "@elewa-group/features/components/buttons"
+import { ButtonsModule } from '@elewa-group/features/components/buttons';
 import { LayoutModule } from '@elewa-group/elements/layout';
 
 import { TeamMembersCarouselComponent } from './components/team-members-carousel/team-members-carousel.component';
@@ -22,6 +21,8 @@ import { NextDirective } from './directives/next.directive';
 import { PrevDirective } from './directives/prev.directive';
 import { AboutUsRoutingModule } from './about-us.routing';
 import { AboutUsHistoryCarouselComponent } from './components/about-us-history-carousel/about-us-history-carousel.component';
+import { AboutUsWeCareComponent } from './components/about-us-we-care/about-us-we-care.component';
+import { CardsModule } from '@elewa-group/features/components/cards';
 
 @NgModule({
   imports: [
@@ -30,7 +31,8 @@ import { AboutUsHistoryCarouselComponent } from './components/about-us-history-c
     CommonModule,
     LayoutModule,
     AboutUsRoutingModule,
-    UiListsModule
+    UiListsModule,
+    CardsModule
   ],
 
   declarations: [
@@ -40,11 +42,9 @@ import { AboutUsHistoryCarouselComponent } from './components/about-us-history-c
     AboutUsCultureComponent,
     AboutUsPageComponent,
     AboutUsHistoryCarouselComponent,
-    ElewaAboutUsLocationSectionComponent
+    ElewaAboutUsLocationSectionComponent,
+    AboutUsWeCareComponent,
   ],
-  exports: [
-    TeamMembersCarouselComponent,
-    ElewaAboutUsLocationSectionComponent
-  ],
+  exports: [TeamMembersCarouselComponent, ElewaAboutUsLocationSectionComponent],
 })
 export class AboutUsModule {}

--- a/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
+++ b/libs/pages/elewa/about-us/src/lib/pages/about-us-page/about-us-page.component.html
@@ -5,6 +5,7 @@
       <elewa-group-about-us-culture></elewa-group-about-us-culture>
       <elewa-group-team-members-carousel></elewa-group-team-members-carousel>
       <elewa-group-about-us-history-carousel></elewa-group-about-us-history-carousel>
+      <elewa-group-about-us-we-care></elewa-group-about-us-we-care>
     </div>
   </elewa-group-elewa-group-main-page> 
 </div>


### PR DESCRIPTION
# Description
A component with a title, 2 paragraphs aligned side by side and columns which are reused from cards module. 


To achieve this, we needed to:
Worked On this with @ItotiaHarrison
```
- Generate the component.
- Import Cards module.
- Reuse the imported component in we-care template.
- Style the component
```

Fixes # (issue 14) -  Reusable Icons and text components

## Type of change
When displaying an image URL instead of a font-awesome icon, i needed to modify the ElewaVerticalIconAndTextComponent to accept an image URL as an input and use an <img> tag instead of an <i> tag in the template. Otherwise, the component will try to look for a font-awesome icon with the name specified in the icon input and won't be able to render the image URL properly.

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)



# Screenshot (optional)
![Screenshot from 2023-02-27 08-33-52](https://user-images.githubusercontent.com/100309346/221760526-deba5986-133a-40d8-ae44-04f342a17135.png)
 - Mobile View
![Screenshot from 2023-02-28 20-33-17](https://user-images.githubusercontent.com/100309346/221934355-841204be-7b4a-48fb-a0bf-ed1d602dc841.png)






# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
