### PR TITLE
#320 Brands stakeholder

### DIFF
--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.html
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.html
@@ -1,0 +1,24 @@
+<p>elewa-brands-stakeholder works!</p>
+<p>elewa-brands-stakeholder works!</p>
+<div class="stakeholder-group">
+    <div class="stakeholder-group-img">
+      <img src="https://res.cloudinary.com/dyl3rncv3/image/upload/v1675690296/elewa-group-website/Icons/SVG/Brands_hfslt4.svg" alt="" />
+    </div>
+    <div class="stakeholder-group-text">
+      <h1 class="stakeholder-group-heading">Elewa NV, a multi-stakeholder cooperation</h1>
+      <div class="stakeholder-group-paragraphs">
+        <p class="stakeholder-group-paragraph">
+          Elewa NV is a multi-stakeholder cooperation based out of Brussels with
+          subsidiaries in Belgium and East-africa. Elewa NV supports the operations
+          of all brands associated to the Elewa family
+        </p>
+        <p class="stakeholder-group-paragraph">
+          More than a company,Elewa is a home for talents across
+          the world. Where they can explore and grow themselves As they find their
+          place, on the path unwinding
+        </p>
+      </div>
+      <a class="stakeholder-group-link">LEARN MORE</a>
+    </div>
+  </div>
+

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.scss
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.scss
@@ -1,0 +1,73 @@
+.stakeholder-group {
+    background-color: var(--elewa-group-website-color-card);
+    border-radius: 30px;
+    margin: 1rem 0;
+    padding: 1rem;
+
+    .stakeholder-group-img {
+      margin-bottom: 1rem;
+
+      img {
+        width: 100%;
+        height: 20rem;
+        transform: rotate(45deg);
+        opacity: .5;
+      }
+    }
+
+    .stakeholder-group-text {
+      width: 90%;
+      font-family: var(--elewa-group-website-dmsans-regular);
+      padding-bottom: 1.5rem;
+
+      .stakeholder-group-heading {
+        font-size: 2.8rem;
+        font-weight: var(--elewa-group-website-font-weight-title);
+        max-width: 80%;
+        margin-bottom: 1rem;
+      }
+
+      .stakeholder-group-paragraphs {
+        margin: 2rem 0;
+        max-width: 100%;
+
+        .stakeholder-group-paragraph {
+          font-weight: var(--elewa-group-website-font-size-description);
+          margin-bottom: 1rem;
+        }
+      }
+
+      .stakeholder-group-link {
+        text-decoration: underline;
+        font-weight: var(--elewa-group-website-font-weight-title);
+        cursor: pointer;
+      }
+    }
+
+    @media only screen and (min-width: 768px) {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 5rem 3rem;
+
+      .stakeholder-group-img {
+        width: 40%;
+      }
+
+      .stakeholder-group-text {
+        width: 60%;
+
+        .stakeholder-group-paragraphs {
+          display: flex;
+          justify-content: space-between;
+          align-items: start;
+          max-width: 90%;
+          padding-right: 7rem;
+
+          .stakeholder-group-paragraph {
+            max-width: 17rem;
+          }
+        }
+      }
+    }
+  }

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.spec.ts
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaBrandsStakeholderComponent } from './elewa-brands-stakeholder.component';
+
+describe('ElewaBrandsStakeholderComponent', () => {
+  let component: ElewaBrandsStakeholderComponent;
+  let fixture: ComponentFixture<ElewaBrandsStakeholderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaBrandsStakeholderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaBrandsStakeholderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.ts
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-stakeholder/elewa-brands-stakeholder.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-brands-stakeholder',
+  templateUrl: './elewa-brands-stakeholder.component.html',
+  styleUrls: ['./elewa-brands-stakeholder.component.scss'],
+})
+export class ElewaBrandsStakeholderComponent {}

--- a/libs/pages/elewa/brands/src/lib/pages-elewa-brands.module.ts
+++ b/libs/pages/elewa/brands/src/lib/pages-elewa-brands.module.ts
@@ -9,9 +9,14 @@ import { ElewaBrandsOpportunitiesComponent } from './components/elewa-brands-opp
 import { ElewaBrandsPageComponent } from './pages/elewa-brands-page/elewa-brands-page/elewa-brands-page.component';
 
 import { BrandsRoutingModule } from './brands.routing';
+import { ElewaBrandsStakeholderComponent } from './components/elewa-brands-stakeholder/elewa-brands-stakeholder.component';
 
 @NgModule({
   imports: [CommonModule, LayoutModule, BannersModule, BrandsRoutingModule],
-  declarations: [ElewaBrandsPageComponent, ElewaBrandsOpportunitiesComponent],
+  declarations: [
+    ElewaBrandsPageComponent,
+    ElewaBrandsOpportunitiesComponent,
+    ElewaBrandsStakeholderComponent,
+  ],
 })
 export class BrandsModule {}

--- a/libs/pages/elewa/brands/src/lib/pages/elewa-brands-page/elewa-brands-page/elewa-brands-page.component.html
+++ b/libs/pages/elewa/brands/src/lib/pages/elewa-brands-page/elewa-brands-page/elewa-brands-page.component.html
@@ -2,6 +2,7 @@
     <elewa-group-elewa-group-main-page>
       <div mainPage class="home-page">
         <elewa-group-elewa-brands-opportunities></elewa-group-elewa-brands-opportunities>
+        <elewa-group-elewa-brands-stakeholder></elewa-group-elewa-brands-stakeholder>
       </div>
     </elewa-group-elewa-group-main-page>
   </div>


### PR DESCRIPTION
# Description

This is a component requirement for a stakeholder section on a brands page. The section should follow a specific design shown in the provided link. As a user, the requirement is to have a visually appealing stakeholder section on the brands page.


To achieve this, we needed to:

```
-  nx g c elewa-brands-stakeholder
- Ensure the component is imported
- Add <elewa-group-elewa-brands-opportunities> to the main brands page
- Add html/scss code 
```

Fixes # (320) - *Example*: Fixes # ([320](https://github.com/italanta/elewa-group/issues/320)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Screenshot (optional)
![Screenshot from 2023-02-28 12-49-50](https://user-images.githubusercontent.com/110177559/221818891-22a5e397-4bf0-4b00-b319-7505cfe67d6a.png)
![Screenshot from 2023-02-28 12-50-46](https://user-images.githubusercontent.com/110177559/221818912-de03147f-f5eb-451d-ae96-b7ad805049ef.png)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration if necessary.
- [ ]  nx serve elewa-group-website

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:


# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
