### PR TITLE
Create reusable article carousel #411

### DIFF
--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.html
@@ -1,0 +1,1 @@
+<p>elewa-group-article-list works!</p>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.html
@@ -1,1 +1,20 @@
-<p>elewa-group-article-list works!</p>
+<div class="article-wrapper">
+  <div class="article-list">
+    <ng-container *ngFor="let article of articles.slice(currentIndex, currentIndex + 3)">
+      <div class="article">
+        <img [src]="article.image" alt="">
+        <div class="info">
+          <span class="timestamp">{{ article.timestamp }} <span class="dot">·</span> <p class="read-time">{{ calculateReadTime(article.body) }} min read </p></span>
+          
+          <p class="title">{{ article.title }}</p>
+          <!-- <p class="body">{{ article.body }}</p> -->
+          
+        </div>
+      </div>
+    </ng-container>
+  </div>
+  <div class="button-wrapper">
+    <button class="prev" (click)="scrollLeft()" [disabled]="currentIndex === 0"><i class="fas fa-arrow-left"></i><p class="btn-text">Prev</p></button>
+    <button class="next" (click)="scrollRight()" [disabled]="currentIndex === articles.length - 3"><p class="btn-text">Next</p><i class="fas fa-arrow-right"></i></button>
+  </div>
+</div>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.html
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.html
@@ -13,6 +13,21 @@
       </div>
     </ng-container>
   </div>
+  <div class="banner-controls">
+    <div class="previous-button">
+      <button class="fa-arrow-left-long" (click)="previousBanner()">
+        <i class="fa-solid fa-arrow-left-long"></i>
+      </button>
+    </div>
+    <div class="next-button">  
+      <button class="fa-arrow-right-long" (click)="nextBanner()">
+        <i class="fa-solid fa-arrow-right-long"></i>
+      </button>
+    </div> 
+  </div>
+  <div class="progress-bar">
+    <div class="progress-bar-fill" [style.width.%]="progressPercentage"></div>
+  </div> 
   <div class="button-wrapper">
     <button class="prev" (click)="scrollLeft()" [disabled]="currentIndex === 0"><i class="fas fa-arrow-left"></i><p class="btn-text">Prev</p></button>
     <button class="next" (click)="scrollRight()" [disabled]="currentIndex === articles.length - 3"><p class="btn-text">Next</p><i class="fas fa-arrow-right"></i></button>

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
@@ -1,4 +1,3 @@
-
 .article-wrapper {
   position: relative;
   margin-top: 50px;
@@ -145,15 +144,106 @@
   margin: 5px; /* adjust the value to change the spacing */
 }
 
+
+// @media (max-width: 767px) {
+//   .article-wrapper {
+//     margin: 0;
+//   }
+  
+//   .article-list {
+//     overflow-x: scroll;
+//     scroll-snap-type: x mandatory;
+//     justify-content: flex-start;
+//   }
+  
+//   .article {
+//     flex: 0 0 100%;
+//     margin-right: 16px;
+//     scroll-snap-align: start;
+//     max-width: 300px;
+//   }
+  
+//   .button-wrapper {
+//     display: flex;
+//     justify-content: space-between;
+//     margin-top: 50px;
+//     width: 100%;
+//   }
+  
+//   .prev, .next {
+//     width: 120px;
+//     height: 48px;
+//     color: black;
+//     font-weight: bold;
+//     font-size: 15px;
+//     transition: 0.6s ease;
+//     border-radius: 60px;
+//     user-select: none;
+//     background-color: white;
+//     display: flex;
+//     align-items: center;
+//     justify-content: center;
+//     margin: 10px;
+//   }
+
+//   .prev i, .next i {
+//     font-size: 20px;
+//     color: gray;
+//     margin-right: 10px;
+//   }
+  
+//   .btn-text {
+//     margin: 5px;
+//   }
+// }
+
+// .banner-controls {
+//   position: absolute;
+//   margin: 10px;
+//   right: 0px;
+//   display: flex;
+//   align-items: center;
+//   margin-left: 5%;
+//   margin-right: 5%;
+//   padding: 0 40px;  
+// }
+
+// .previous-button,
+// .next-button {
+//   display: flex;
+//   border-width: 0.1px;
+//   border-style: inset;
+//   color: black;
+//   width: 30px;
+//   height: 30px;
+//   border-radius: 50%;
+//   align-items: center;
+//   justify-content: center;
+//   margin-left:10px;
+  
+//   // position: absolute;
+// }
+
+// .fa-arrow-left-long,
+// .fa-arrow-right-long {
+//   color: black;
+//   font-size: 10px;
+//   font-weight: lighter;
+//   cursor: pointer;
+//   background: none;
+//   border: none;
+// }
+
 @media (max-width: 767px) {
   .article-wrapper {
-    margin: 0;
+    margin: 60px;
   }
   
   .article-list {
-    overflow-x: scroll;
+     overflow-x: scroll;
     scroll-snap-type: x mandatory;
     justify-content: flex-start;
+  
   }
   
   .article {
@@ -166,7 +256,7 @@
   .button-wrapper {
     display: flex;
     justify-content: space-between;
-    margin-top: 50px;
+    
     width: 100%;
   }
   
@@ -183,7 +273,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: 10px;
   }
 
   .prev i, .next i {
@@ -194,5 +283,86 @@
   
   .btn-text {
     margin: 5px;
+  }
+
+  .banner-controls {
+    position: absolute;
+ 
+    right: 0px;
+    display: flex;
+    align-items: center;
+    
+    margin-right: 0;
+    margin-bottom: 10px;  
+  }
+
+  .previous-button,
+  .next-button {
+    display: flex;
+    border-width: 0.5px;
+    border-style: inset;
+    color: black;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    align-items: center;
+    justify-content: center;
+    margin-left:10px;
+  
+    // position: absolute;
+  }
+
+  .fa-arrow-left-long,
+  .fa-arrow-right-long {
+    color: black;
+    font-size: 10px;
+    font-weight: lighter;
+    cursor: pointer;
+    background: none;
+    border: none;
+  }
+
+.progress-bar {
+  width: 100%;
+  height: 1px;
+  background-color: black;
+  position: absolute;
+  margin-top: 40px;
+
+  font-size: 100px;
+  color: white;
+  font-weight: bolder;
+}
+
+.progress-bar-fill {
+  background-color: black;
+  height: 5px;
+  font-weight: bolder;
+  font-size: 100px;
+}
+
+.article-list::-webkit-scrollbar {
+  background-color: white;
+
+}
+
+.article-list::-webkit-scrollbar-thumb {
+  background-color: white;
+  
+}
+
+.article-list::-webkit-scrollbar-thumb:hover {
+  background-color: white;
+}
+
+}
+
+@media only screen and (min-width: 768px) {
+  .banner-controls,
+  .progress-bar,
+  .previous-button,
+  .next-button
+   {
+    display: none;
   }
 }

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
@@ -16,6 +16,7 @@
   overflow-x: hidden; /* remove this to disable scrolling */
   scroll-snap-type: x mandatory;
   justify-content: space-between;
+  
 }
 
 .article {
@@ -28,8 +29,8 @@
 }
 
 .article img {
-  width: 275px;
-  height: 300px;
+  width: 300px;
+  height: 350px;
   object-fit: cover;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
@@ -132,14 +133,7 @@
   margin: 10px;
 }
 
-.next {
-  // margin-right: 24%;
-  padding: 10px;
-}
 
-.prev {
-//   margin-left: 22%;
- }
 
 .prev i,
 .next i {
@@ -151,3 +145,54 @@
   margin: 5px; /* adjust the value to change the spacing */
 }
 
+@media (max-width: 767px) {
+  .article-wrapper {
+    margin: 0;
+  }
+  
+  .article-list {
+    overflow-x: scroll;
+    scroll-snap-type: x mandatory;
+    justify-content: flex-start;
+  }
+  
+  .article {
+    flex: 0 0 100%;
+    margin-right: 16px;
+    scroll-snap-align: start;
+    max-width: 300px;
+  }
+  
+  .button-wrapper {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 50px;
+    width: 100%;
+  }
+  
+  .prev, .next {
+    width: 120px;
+    height: 48px;
+    color: black;
+    font-weight: bold;
+    font-size: 15px;
+    transition: 0.6s ease;
+    border-radius: 60px;
+    user-select: none;
+    background-color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 10px;
+  }
+
+  .prev i, .next i {
+    font-size: 20px;
+    color: gray;
+    margin-right: 10px;
+  }
+  
+  .btn-text {
+    margin: 5px;
+  }
+}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
@@ -1,0 +1,147 @@
+
+.article-wrapper {
+  position: relative;
+}
+
+.article-list {
+  position: relative; /* add this to make the position of the buttons relative to this container */
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: hidden; /* remove this to disable scrolling */
+  scroll-snap-type: x mandatory;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.article {
+  display: flex;
+  flex-direction: column;
+  scroll-snap-align: center;
+  width: 250px;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.article img {
+  width: 210px;
+  height: 250px;
+  object-fit: cover;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
+.article .info {
+  font-family: var(  --elewa-group-website-dmsans-regular);
+  padding: 10px;
+  background-color: white;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+
+.article .info .title {
+  // font-family: var(  --elewa-group-website-dmsans-regular);
+  // font-size: 1.2rem;
+  // font-weight: bold;
+  // margin-bottom: 5px;
+  margin-top: 10px;
+  font-family: var(  --elewa-group-website-dmsans-regular);
+   flex-grow: 1;
+}
+
+//  .article .info .body {
+//    font-family: var(  --elewa-group-website-dmsans-regular);
+//    flex-grow: 1;
+//  }
+
+// .article .info .read-time {
+//   font-family: var(  --elewa-group-website-dmsans-regular);
+//   font-size: 0.8rem;
+//   color: gray;
+//   margin-left: 10px;
+//   display: inline-block;
+// }
+
+.article .info .timestamp {
+  font-family: var(--elewa-group-website-dmsans-regular);
+  flex-direction: row; /* changed to row */
+
+  font-size: 0.8rem;
+  color: black;
+  margin-top: 10px;
+  display: flex; /* added */
+  align-items: center; /* added */
+}
+
+.timestamp .dot {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 0 0.5rem;
+}
+
+.article .info .read-time {
+  font-family: var(--elewa-group-website-dmsans-regular);
+  font-size: 0.6rem;
+  color: black;
+  display: flex; /* added */
+
+}
+
+
+
+
+
+
+
+
+
+.button-wrapper {
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 50px;
+  width: 100%;
+}
+
+.prev, .next {
+  cursor: pointer;
+  width: 120px;
+  height: 48px;
+  color: black;
+  font-weight: bold;
+  font-size: 15px;
+  transition: 0.6s ease;
+  border-radius: 60px;
+  user-select: none;
+  background-color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 10px;
+}
+
+.next {
+  margin-right: 24%;
+  padding: 10px;
+}
+
+.prev {
+  margin-left: 22%;
+}
+
+.prev i,
+.next i {
+  font-size: 20px;
+  color: gray;
+  margin-right: 10px;
+}
+.btn-text {
+  margin: 5px; /* adjust the value to change the spacing */
+}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
@@ -4,12 +4,12 @@
   margin-bottom: 20px;
   margin-left: 80px;
   margin-right: 80px;
-  justify-content: flex-start; /* change to flex-start to reduce space between articles */
+  justify-content: flex-start;
 
 }
 
 .article-list {
-  position: relative; /* add this to make the position of the buttons relative to this container */
+  position: relative; 
   display: flex;
   flex-wrap: nowrap;
   overflow-x: hidden; /* remove this to disable scrolling */
@@ -52,37 +52,21 @@
 }
 
 .article .info .title {
-  // font-family: var(  --elewa-group-website-dmsans-regular);
-  // font-size: 1.2rem;
-  // font-weight: bold;
-  // margin-bottom: 5px;
   margin-top: 10px;
   font-family: var(  --elewa-group-website-dmsans-regular);
    flex-grow: 1;
 }
 
-//  .article .info .body {
-//    font-family: var(  --elewa-group-website-dmsans-regular);
-//    flex-grow: 1;
-//  }
-
-// .article .info .read-time {
-//   font-family: var(  --elewa-group-website-dmsans-regular);
-//   font-size: 0.8rem;
-//   color: gray;
-//   margin-left: 10px;
-//   display: inline-block;
-// }
 
 .article .info .timestamp {
   font-family: var(--elewa-group-website-dmsans-regular);
-  flex-direction: row; /* changed to row */
+  flex-direction: row; 
 
   font-size: 0.8rem;
   color: black;
   margin-top: 10px;
-  display: flex; /* added */
-  align-items: center; /* added */
+  display: flex; 
+  align-items: center; 
 }
 
 .timestamp .dot {
@@ -95,16 +79,9 @@
   font-family: var(--elewa-group-website-dmsans-regular);
   font-size: 0.6rem;
   color: black;
-  display: flex; /* added */
+  display: flex; 
 
 }
-
-
-
-
-
-
-
 
 
 .button-wrapper {
@@ -143,96 +120,6 @@
 .btn-text {
   margin: 5px; /* adjust the value to change the spacing */
 }
-
-
-// @media (max-width: 767px) {
-//   .article-wrapper {
-//     margin: 0;
-//   }
-  
-//   .article-list {
-//     overflow-x: scroll;
-//     scroll-snap-type: x mandatory;
-//     justify-content: flex-start;
-//   }
-  
-//   .article {
-//     flex: 0 0 100%;
-//     margin-right: 16px;
-//     scroll-snap-align: start;
-//     max-width: 300px;
-//   }
-  
-//   .button-wrapper {
-//     display: flex;
-//     justify-content: space-between;
-//     margin-top: 50px;
-//     width: 100%;
-//   }
-  
-//   .prev, .next {
-//     width: 120px;
-//     height: 48px;
-//     color: black;
-//     font-weight: bold;
-//     font-size: 15px;
-//     transition: 0.6s ease;
-//     border-radius: 60px;
-//     user-select: none;
-//     background-color: white;
-//     display: flex;
-//     align-items: center;
-//     justify-content: center;
-//     margin: 10px;
-//   }
-
-//   .prev i, .next i {
-//     font-size: 20px;
-//     color: gray;
-//     margin-right: 10px;
-//   }
-  
-//   .btn-text {
-//     margin: 5px;
-//   }
-// }
-
-// .banner-controls {
-//   position: absolute;
-//   margin: 10px;
-//   right: 0px;
-//   display: flex;
-//   align-items: center;
-//   margin-left: 5%;
-//   margin-right: 5%;
-//   padding: 0 40px;  
-// }
-
-// .previous-button,
-// .next-button {
-//   display: flex;
-//   border-width: 0.1px;
-//   border-style: inset;
-//   color: black;
-//   width: 30px;
-//   height: 30px;
-//   border-radius: 50%;
-//   align-items: center;
-//   justify-content: center;
-//   margin-left:10px;
-  
-//   // position: absolute;
-// }
-
-// .fa-arrow-left-long,
-// .fa-arrow-right-long {
-//   color: black;
-//   font-size: 10px;
-//   font-weight: lighter;
-//   cursor: pointer;
-//   background: none;
-//   border: none;
-// }
 
 @media (max-width: 767px) {
   .article-wrapper {
@@ -308,8 +195,7 @@
     align-items: center;
     justify-content: center;
     margin-left:10px;
-  
-    // position: absolute;
+
   }
 
   .fa-arrow-left-long,

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
@@ -1,9 +1,12 @@
 
 .article-wrapper {
   position: relative;
-  margin: 80px;
+  margin-top: 50px;
+  margin-bottom: 20px;
+  margin-left: 80px;
+  margin-right: 80px;
   justify-content: flex-start; /* change to flex-start to reduce space between articles */
- 
+
 }
 
 .article-list {
@@ -148,29 +151,3 @@
   margin: 5px; /* adjust the value to change the spacing */
 }
 
-@media (max-width: 767px) {
-  .article-list {
-    overflow-x: scroll;
-    scroll-snap-type: x mandatory;
-  }
-
-  .article {
-    width: 100%;
-    margin-right: 20px;
-    scroll-snap-align: start;
-  }
-
-  .button-wrapper {
-    margin-top: 20px;
-  }
-
-  .prev,
-  .next {
-    margin: 10px;
-  }
-
-  .prev i,
-  .next i {
-    margin-right: 5px;
-  }
-}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.scss
@@ -1,6 +1,9 @@
 
 .article-wrapper {
   position: relative;
+  margin: 80px;
+  justify-content: flex-start; /* change to flex-start to reduce space between articles */
+ 
 }
 
 .article-list {
@@ -9,8 +12,7 @@
   flex-wrap: nowrap;
   overflow-x: hidden; /* remove this to disable scrolling */
   scroll-snap-type: x mandatory;
-  justify-content: center;
-  margin-top: 20px;
+  justify-content: space-between;
 }
 
 .article {
@@ -23,8 +25,8 @@
 }
 
 .article img {
-  width: 210px;
-  height: 250px;
+  width: 275px;
+  height: 300px;
   object-fit: cover;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
@@ -128,13 +130,13 @@
 }
 
 .next {
-  margin-right: 24%;
+  // margin-right: 24%;
   padding: 10px;
 }
 
 .prev {
-  margin-left: 22%;
-}
+//   margin-left: 22%;
+ }
 
 .prev i,
 .next i {
@@ -144,4 +146,31 @@
 }
 .btn-text {
   margin: 5px; /* adjust the value to change the spacing */
+}
+
+@media (max-width: 767px) {
+  .article-list {
+    overflow-x: scroll;
+    scroll-snap-type: x mandatory;
+  }
+
+  .article {
+    width: 100%;
+    margin-right: 20px;
+    scroll-snap-align: start;
+  }
+
+  .button-wrapper {
+    margin-top: 20px;
+  }
+
+  .prev,
+  .next {
+    margin: 10px;
+  }
+
+  .prev i,
+  .next i {
+    margin-right: 5px;
+  }
 }

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.spec.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaGroupArticleListComponent } from './elewa-group-article-list.component';
+
+describe('ElewaGroupArticleListComponent', () => {
+  let component: ElewaGroupArticleListComponent;
+  let fixture: ComponentFixture<ElewaGroupArticleListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaGroupArticleListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaGroupArticleListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -1,31 +1,20 @@
 import { Component, Input } from '@angular/core';
-
 //import this interface in the component you will be reusing article-list in. e.g
 //import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
-
 export interface Article {
   image: string;
   timestamp: string;
   title: string;
   body: string;
 }
-
 @Component({
   selector: 'elewa-group-elewa-group-article-list',
   templateUrl: './elewa-group-article-list.component.html',
   styleUrls: ['./elewa-group-article-list.component.scss'],
 })
-export class ElewaGroupArticleListComponent {
-
-  @Input() articles: Article[
-
-    
-  ];
-
-
-  currentIndex = 0;
-
-
+export class ElewaGroupArticleListComponent {  
+@Input() articles: Article[];
+ currentIndex = 0;
   calculateReadTime(body: string): number {
     const wordCount = body.split(' ').length;
     const readTime = Math.round(wordCount / 200);
@@ -53,5 +42,4 @@ export class ElewaGroupArticleListComponent {
       });
     }
   }
-  
-}
+  }

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-group-article-list',
+  templateUrl: './elewa-group-article-list.component.html',
+  styleUrls: ['./elewa-group-article-list.component.scss'],
+})
+export class ElewaGroupArticleListComponent {}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -1,8 +1,57 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+//import this interface in the component you will be reusing article-list in. e.g
+//import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
+
+export interface Article {
+  image: string;
+  timestamp: string;
+  title: string;
+  body: string;
+}
 
 @Component({
   selector: 'elewa-group-elewa-group-article-list',
   templateUrl: './elewa-group-article-list.component.html',
   styleUrls: ['./elewa-group-article-list.component.scss'],
 })
-export class ElewaGroupArticleListComponent {}
+export class ElewaGroupArticleListComponent {
+
+  @Input() articles: Article[
+
+    
+  ];
+
+
+  currentIndex = 0;
+
+
+  calculateReadTime(body: string): number {
+    const wordCount = body.split(' ').length;
+    const readTime = Math.round(wordCount / 200);
+    return readTime;
+  }
+
+  scrollLeft() {
+    if (this.currentIndex > 0) {
+      this.currentIndex--;
+      const element = document.querySelector('.article-list');
+      element?.scrollBy({
+        left: -900,
+        behavior: 'smooth'
+      });
+    }
+  }
+  
+  scrollRight() {
+    if (this.currentIndex < this.articles.length - 3) {
+      this.currentIndex++;
+      const element = document.querySelector('.article-list');
+      element?.scrollBy({
+        left: 900,
+        behavior: 'smooth'
+      });
+    }
+  }
+  
+}

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -42,4 +42,19 @@ export class ElewaGroupArticleListComponent {
       });
     }
   }
+
+ 
+
+  nextBanner() {
+    this.currentIndex = (this.currentIndex + 1) % this.articles.length;
+  }
+
+  previousBanner() {
+    this.currentIndex = (this.currentIndex - 1 + this.articles.length) % this.articles.length;
+  }
+  
+  get progressPercentage() {
+    return (this.currentIndex + 1) / this.articles.length * 100;
+  }
+  
   }

--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -1,20 +1,16 @@
 import { Component, Input } from '@angular/core';
-//import this interface in the component you will be reusing article-list in. e.g
-//import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
-export interface Article {
-  image: string;
-  timestamp: string;
-  title: string;
-  body: string;
-}
+export interface Article { image: string; timestamp: string; title: string; body: string;} //import this interface in the component you will be reusing article-list in. e.g import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
+
 @Component({
   selector: 'elewa-group-elewa-group-article-list',
   templateUrl: './elewa-group-article-list.component.html',
   styleUrls: ['./elewa-group-article-list.component.scss'],
 })
+
 export class ElewaGroupArticleListComponent {  
 @Input() articles: Article[];
- currentIndex = 0;
+
+currentIndex = 0;
   calculateReadTime(body: string): number {
     const wordCount = body.split(' ').length;
     const readTime = Math.round(wordCount / 200);
@@ -30,8 +26,7 @@ export class ElewaGroupArticleListComponent {
         behavior: 'smooth'
       });
     }
-  }
-  
+  } 
   scrollRight() {
     if (this.currentIndex < this.articles.length - 3) {
       this.currentIndex++;
@@ -42,19 +37,13 @@ export class ElewaGroupArticleListComponent {
       });
     }
   }
-
- 
-
   nextBanner() {
     this.currentIndex = (this.currentIndex + 1) % this.articles.length;
   }
-
   previousBanner() {
     this.currentIndex = (this.currentIndex - 1 + this.articles.length) % this.articles.length;
   }
-  
-  get progressPercentage() {
+    get progressPercentage() {
     return (this.currentIndex + 1) / this.articles.length * 100;
   }
-  
-  }
+   }

--- a/libs/features/components/ui-lists/src/lib/features-components-ui-lists.module.ts
+++ b/libs/features/components/ui-lists/src/lib/features-components-ui-lists.module.ts
@@ -4,14 +4,21 @@ import { CommonModule } from '@angular/common';
 import { ElewaGroupVerticalListOneComponent } from './elewa-group-vertical-list-one/elewa-group-vertical-list-one.component';
 import { ElewaHorizontalTimelineCarouselComponent } from './elewa-horizontal-timeline-carousel/elewa-horizontal-timeline-carousel.component';
 import { ElewaGroupHorizontalListOrgsComponent } from './elewa-group-horizontal-list-orgs/elewa-group-horizontal-list-orgs.component';
+import { ElewaGroupArticleListComponent } from './elewa-group-article-list/elewa-group-article-list.component';
 
 @NgModule({
   imports: [CommonModule],
   declarations: [
     ElewaGroupVerticalListOneComponent,
     ElewaGroupHorizontalListOrgsComponent,
-    ElewaHorizontalTimelineCarouselComponent
+    ElewaHorizontalTimelineCarouselComponent,
+    ElewaGroupArticleListComponent,
   ],
-  exports: [ElewaGroupVerticalListOneComponent, ElewaGroupHorizontalListOrgsComponent, ElewaHorizontalTimelineCarouselComponent],
+  exports: [
+    ElewaGroupVerticalListOneComponent,
+    ElewaGroupHorizontalListOrgsComponent,
+    ElewaHorizontalTimelineCarouselComponent,
+    ElewaGroupArticleListComponent,
+  ],
 })
-export class UiListsModule { }
+export class UiListsModule {}


### PR DESCRIPTION
# Description

Created reusable article carousel


Example
This pull request solves issue #411 

To achieve this:

```
- We created elewa-group-article-list component in the ui-lists lib
- carousel button functionality was implemented 
- Both mobile view and desktop view were covered.
- the mobile view includes a progress bar, a scroll bar, and two extra buttons. 
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


# Screenshot (optional)

# Video
[screen-capture (3).webm](https://user-images.githubusercontent.com/48943229/223361988-550c6392-9b2d-458c-9767-adff1bd064cd.webm)



# How Has This Been Tested?

This was tested on the development server and was working

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
