### PR TITLE
art Create venture labs info section #402

### DIFF
--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/elewa-brands-venture-labs.component.html
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/elewa-brands-venture-labs.component.html
@@ -7,3 +7,4 @@
  [logoPlacement]="logoPlacement">
 
 </elewa-group-elewa-group-brands>
+<elewa-group-venture-labs-info></elewa-group-venture-labs-info>

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.html
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.html
@@ -1,0 +1,14 @@
+<div class="container">
+  <p>
+    Elewa group is funded by sustainable, EBITDA positive,business <br>
+    ventures which lie at the core of the group. These include Elewa <br> Education, EdTech and Education consulting, and iTalanta, our <br>
+     largest activity of IT offshoring activities.
+  </p>
+  <br>
+  <br>
+  <p>
+    Sheltered by the group's stable business and strong cashflows, <br>
+     Elewa's culture and Venture Labs allow for creative exploration of <br>
+    new business ideas and moonshot startup ventures.
+  </p>
+</div>

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.scss
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.scss
@@ -1,0 +1,16 @@
+.container {
+  background-color: #F4F4F4;
+  width: 100%;
+  margin: auto;
+  padding: 20px;
+  padding-left: 150px;
+  padding-top: 30px;
+  border-radius:0 0 25px 25px;
+}
+
+p {
+  font-family: var(--elewa-group-website-dmsans-regular);
+  font-size: var(--elewa-group-website-font-size-elewa-text-medium);
+  line-height: 1.5;
+  margin-bottom: 20px;
+}

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.spec.ts
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VentureLabsInfoComponent } from './venture-labs-info.component';
+
+describe('VentureLabsInfoComponent', () => {
+  let component: VentureLabsInfoComponent;
+  let fixture: ComponentFixture<VentureLabsInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VentureLabsInfoComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VentureLabsInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.ts
+++ b/libs/pages/elewa/brands/src/lib/components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-venture-labs-info',
+  templateUrl: './venture-labs-info.component.html',
+  styleUrls: ['./venture-labs-info.component.scss']
+})
+export class VentureLabsInfoComponent {
+
+}

--- a/libs/pages/elewa/brands/src/lib/pages-elewa-brands.module.ts
+++ b/libs/pages/elewa/brands/src/lib/pages-elewa-brands.module.ts
@@ -14,6 +14,7 @@ import { ElewaBrandsCreativeHubComponent } from './components/elewa-brands-creat
 import { ElewaBrandsPageComponent } from './pages/elewa-brands-page/elewa-brands-page/elewa-brands-page.component';
 
 import { BrandsRoutingModule } from './brands.routing';
+import { VentureLabsInfoComponent } from './components/elewa-brands-venture-labs/venture-labs-info/venture-labs-info.component';
 
 @NgModule({
   imports: [CommonModule, LayoutModule, BannersModule, BrandsRoutingModule],
@@ -26,6 +27,7 @@ import { BrandsRoutingModule } from './brands.routing';
     ElewaBrandsStakeholderComponent,
     ElewaBrandsHeroComponent,
     ElewaBrandsCreativeHubComponent,
+    VentureLabsInfoComponent,
   ],
 })
 export class BrandsModule {}


### PR DESCRIPTION
# Description

[Awadh](https://github.com/order6677) and I was working on this.

To achieve this, we needed to:

```
- Find the best Gitbook plugin which can do the work
- create a new component called venture-labs-info in libs/pages/elewa/venture-labs
- Make it visible on the page so users can notice it easily
```

Fixes # (Create venture labs info section #402))

# Screenshot (optional)
![Screenshot from 2023-03-07 14-46-02](https://user-images.githubusercontent.com/105648993/223418329-aa5f9c3d-6fc2-496f-bfd6-814322ac6b67.png)
![Screenshot from 2023-03-07 14-46-19](https://user-images.githubusercontent.com/105648993/223418478-bb15a3fe-5c7e-46be-a0a6-73f86f27e622.png)

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
