### PR TITLE
443/elewa news section

### DIFF
--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input } from '@angular/core';
-export interface Article { image: string; timestamp: string; title: string; body: string;} //import this interface in the component you will be reusing article-list in. e.g import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
+export interface Article { 
+  image: string; 
+  timestamp: string; 
+  title: string; 
+  body: string;
+  topic: "elewa" | "all-news" | "italanta" | "press" | "venture-labs";
+} //import this interface in the component you will be reusing article-list in. e.g import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
 
 @Component({
   selector: 'elewa-group-elewa-group-article-list',

--- a/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.html
+++ b/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.html
@@ -1,0 +1,1 @@
+<button (click)="clickHandler()">{{innerText}}</button>

--- a/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.scss
+++ b/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.scss
@@ -1,0 +1,23 @@
+button {
+    padding: 6px 12px;
+    border-radius: 16px;
+    background-color: white;
+    width: 150px;
+    transition-duration: 0.4s;
+    text-transform: capitalize;
+    margin-right: 15px;
+
+}
+
+button:hover {
+    background-color: #000000; /* Black */
+    color: #f4f4f4;
+  }
+
+  @media only screen and (min-width: 425px) {
+	button {
+		display: inline-block;
+        width: 150px;
+	}
+
+  }

--- a/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.spec.ts
+++ b/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonPlainComponent } from './button-plain.component';
+
+describe('ButtonPlainComponent', () => {
+  let component: ButtonPlainComponent;
+  let fixture: ComponentFixture<ButtonPlainComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ButtonPlainComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonPlainComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.ts
+++ b/libs/pages/elewa/news/src/lib/components/button-plain/button-plain.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, Output, EventEmitter} from '@angular/core';
+
+
+@Component({
+  selector: 'elewa-group-button-plain',
+  templateUrl: './button-plain.component.html',
+  styleUrls: ['./button-plain.component.scss'],
+})
+export class ButtonPlainComponent {
+  @Input() innerText:string
+  @Output() queryString:EventEmitter<string>
+  constructor(){
+    this.innerText = "Click Me";
+    this.queryString = new EventEmitter();
+  }
+  clickHandler():void{
+    this.queryString.emit(this.innerText)
+  }
+}

--- a/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.html
+++ b/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.html
@@ -1,0 +1,18 @@
+<div>
+    <div class="title">
+        <h1>News & Stories </h1>
+    </div>    
+    <div class="filter-section">
+        <elewa-group-button-plain [innerText]="'all-news'" (queryString)="filterSelector($event)" />
+        <elewa-group-button-plain [innerText]="'elewa'" (queryString)="filterSelector($event)" />
+        <elewa-group-button-plain [innerText]="'italanta'" (queryString)="filterSelector($event)" />
+        <elewa-group-button-plain [innerText]="'venture-labs'" (queryString)="filterSelector($event)" />
+        <elewa-group-button-plain [innerText]="'press'" (queryString)="filterSelector($event)" />
+    </div>
+
+    <div class="articles">
+        <elewa-group-elewa-group-article-list [articles]="selectedArticles"></elewa-group-elewa-group-article-list>
+    </div>
+</div>    
+
+             

--- a/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.scss
+++ b/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.scss
@@ -1,0 +1,26 @@
+h1{
+    margin-left: 80px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    // font-family: 'DMSans-Bold';
+    font-family: var(--elewa-group-website-dmsans-bold);
+}
+
+.filter-section{
+    display: flex;
+    margin-left: 80px;
+
+}
+
+@media only screen and (min-width: 425px) {
+	.filter-section {
+		padding: 10px;
+		margin-left: 40px;
+        display: inline-block;  
+	}
+
+    h1 {
+        font-size: 2rem;
+        margin-left: 50px;
+    }
+}

--- a/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.spec.ts
+++ b/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewsSectionComponent } from './news-section.component';
+
+describe('NewsSectionComponent', () => {
+  let component: NewsSectionComponent;
+  let fixture: ComponentFixture<NewsSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NewsSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewsSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.ts
+++ b/libs/pages/elewa/news/src/lib/components/news-section/news-section.component.ts
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
+
+@Component({
+  selector: 'elewa-group-news-section',
+  templateUrl: './news-section.component.html',
+  styleUrls: ['./news-section.component.scss'],
+})
+export class NewsSectionComponent {
+  #articles:Article[];
+  selectedArticles:Article[]
+  constructor(){
+    this.#articles = [
+      {
+        image: "https://images.unsplash.com/photo-1579165466949-3180a3d056d5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+        timestamp: "27 Nov 2022",
+        title: "Angular Lifecycle methods",
+        topic:'elewa',
+        body: "somethsijdnndjkfvjdfv jfjdfj dfjfdjdfnjd"
+      },
+      {
+        image: "https://images.unsplash.com/photo-1555019877-f3eb6deb89d1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1172&q=80",
+        timestamp: "22 Nov 2022",
+        title: "The case against Non-null Assertion Operator",
+        topic:"italanta",
+        body: "somethsijdnndjkfvjdfv jfjdfj dfjfdjdfnjd"
+      },
+      {
+        image: "https://images.unsplash.com/photo-1492551557933-34265f7af79e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+        timestamp: "20 Nov 2022",
+        title: "Italanta Academy Launched in Kakuma",
+        topic: "press",
+        body: "somethsijdnndjkfvjdfv jfjdfj dfjfdjdfnjd"
+      },
+      {
+        image: "https://images.unsplash.com/photo-1456324463128-7ff6903988d8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+        timestamp: "20 Nov 2022",
+        title: "Introducing conversational Learning",
+        topic: "elewa",
+        body: "somethsijdnndjkfvjdfv jfjdfj dfjfdjdfnjd"
+      },
+      {
+        image: "https://images.unsplash.com/reserve/wi9yf7kTQxCNeY72cCY6_Images%20of%20Jenny%20Lace%20Plasticity%20Publish%20%284%20of%2025%29.jpg?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+        timestamp: "23 Sept 2022",
+        title: "The case against Non-null Assertion Operator",
+        topic: "venture-labs",
+        body: "somethsijdnndjkfvjdfv jfjdfj dfjfdjdfnjd"
+      }
+
+    ];
+    this.selectedArticles = this.selectedArticles || this.#articles
+  }
+  filterSelector(message:string):void{
+    this.selectedArticles = this.filterArticles(message)    
+  }
+
+  filterArticles(query:string):Article[]{
+    if(query !== "all-news"){
+      return this.#articles.filter(article => article.topic.toLowerCase().includes(query.toLowerCase()))
+    }
+    return this.#articles
+  }
+
+}
+

--- a/libs/pages/elewa/news/src/lib/pages-elewa-news.module.ts
+++ b/libs/pages/elewa/news/src/lib/pages-elewa-news.module.ts
@@ -3,9 +3,12 @@ import { CommonModule } from '@angular/common';
 import { NewsPageComponent } from './pages/news-page/news-page.component';
 import { LayoutModule } from '@elewa-group/elements/layout';
 import { NewsRoutingModule } from './news.routing';
+import { NewsSectionComponent } from './components/news-section/news-section.component';
+import { ButtonPlainComponent } from './components/button-plain/button-plain.component';
+import { UiListsModule } from '@elewa-group/features/components/ui-lists';
 
 @NgModule({
-  imports: [CommonModule, NewsRoutingModule, LayoutModule],
-  declarations: [NewsPageComponent],
+  imports: [CommonModule, NewsRoutingModule, LayoutModule, UiListsModule],
+  declarations: [NewsPageComponent, NewsSectionComponent, ButtonPlainComponent],
 })
 export class NewsPageModule {}

--- a/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
+++ b/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
@@ -6,3 +6,4 @@
         </div>
     </elewa-group-elewa-group-main-page>
 </div>
+

--- a/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
+++ b/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
@@ -2,7 +2,7 @@
 <div>
     <elewa-group-elewa-group-main-page>
         <div mainPage class="home-page">
-            <elewa-group-news-section></elewa-group-news-section>  
+            <elewa-group-news-section>news</elewa-group-news-section>  
         </div>
     </elewa-group-elewa-group-main-page>
 </div>

--- a/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
+++ b/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
@@ -2,7 +2,7 @@
 <div>
     <elewa-group-elewa-group-main-page>
         <div mainPage class="home-page">
-            <elewa-group-news-section>news</elewa-group-news-section>  
+            <elewa-group-news-section></elewa-group-news-section>  
         </div>
     </elewa-group-elewa-group-main-page>
 </div>

--- a/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
+++ b/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
@@ -5,4 +5,5 @@
           
         </div>
     </elewa-group-elewa-group-main-page>
+    <elewa-group-news-section></elewa-group-news-section>
 </div>

--- a/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
+++ b/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
@@ -2,8 +2,7 @@
 <div>
     <elewa-group-elewa-group-main-page>
         <div mainPage class="home-page">
-          
+            <elewa-group-news-section></elewa-group-news-section>  
         </div>
     </elewa-group-elewa-group-main-page>
-    <elewa-group-news-section></elewa-group-news-section>
 </div>


### PR DESCRIPTION
# Description

This entailed adding a tabbed news section.

To achieve this, we needed to:
Use  ngSwitch to implements the tabs

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
Mobile view:
![Screenshot from 2023-03-09 15-04-08](https://user-images.githubusercontent.com/106229835/224144328-6d956dde-d0b4-4c58-a0cd-05353474fb9a.png)
![Screenshot from 2023-03-09 15-03-15](https://user-images.githubusercontent.com/106229835/224144383-eb14740d-9528-4d94-ba2b-46a5a815ab52.png)

Desktop view:
![Screenshot from 2023-03-09 15-02-24](https://user-images.githubusercontent.com/106229835/224144903-41954764-3b75-42ab-9e3c-43d7c82a2f8b.png)
![Screenshot from 2023-03-09 15-01-31](https://user-images.githubusercontent.com/106229835/224144932-6e3d80d9-e1e8-4922-b027-0b517ad9c5fc.png)




# How Has This Been Tested?
Testing responsiveness on web browser.
Testing functionality of tabs.


# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
