### PR TITLE
🎨create news detail related articles section #445

### DIFF
--- a/libs/pages/elewa/news-detail/src/lib/pages-elewa-news-detail.module.ts
+++ b/libs/pages/elewa/news-detail/src/lib/pages-elewa-news-detail.module.ts
@@ -4,9 +4,10 @@ import { CommonModule } from '@angular/common';
 import { LayoutModule } from '@elewa-group/elements/layout';
 
 import { NewsDetailPageComponent } from './pages/news-detail-page/news-detail-page.component';
+import { NewsRelatedArticlesComponent } from './pages/news-related-articles/news-related-articles.component';
 
 @NgModule({
   imports: [CommonModule, LayoutModule],
-  declarations: [NewsDetailPageComponent],
+  declarations: [NewsDetailPageComponent, NewsRelatedArticlesComponent],
 })
 export class ElewaNewsDetailModule {}

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
@@ -1,0 +1,1 @@
+<p>news-related-articles works!</p>

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
@@ -1,1 +1,26 @@
-<p>news-related-articles works!</p>
+<h1>Related Articles</h1>
+<div class="container">
+  <div class="card">
+    <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-16_r7nfrz.png" alt="" srcset="">
+    <p>Introducing Conversational learning ipsum dolar.</p>
+    <span class="card-date">20 Oct 2022</span>
+    <span class="dot">&#183;</span>
+    <span class="card-timestamp">5 min read</span>
+  </div>
+  <div class="card">
+    <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-43_ihgsdr.png" alt="" srcset="">
+    <p>Introducing Conversational learning ipsum dolar.</p>
+    <span class="card-date">20 Oct 2022</span>
+    <span class="dot">&#183;</span>
+    <span class="card-timestamp">5 min read</span>
+  </div>
+  <div class="card">
+    <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-28_ct81ae.png" alt="" srcset="">
+    <p>Introducing Conversational learning ipsum dolar.</p>
+    <span class="card-date">20 Oct 2022</span>
+    <span class="dot">&#183;</span>
+    <span class="card-timestamp">5 min read</span>
+  </div>
+  <div></div>
+  <div></div>
+</div>

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
@@ -2,21 +2,21 @@
 <div class="container">
   <div class="card">
     <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-16_r7nfrz.png" alt="" srcset="">
-    <p>Introducing Conversational learning ipsum dolar.</p>
+    <p>Introducing Conversational learning ipsum dolar</p>
     <span class="card-date">20 Oct 2022</span>
     <span class="dot">&#183;</span>
     <span class="card-timestamp">5 min read</span>
   </div>
   <div class="card">
     <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-43_ihgsdr.png" alt="" srcset="">
-    <p>Introducing Conversational learning ipsum dolar.</p>
+    <p>Introducing Conversational learning ipsum dolar</p>
     <span class="card-date">20 Oct 2022</span>
     <span class="dot">&#183;</span>
     <span class="card-timestamp">5 min read</span>
   </div>
   <div class="card">
     <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-28_ct81ae.png" alt="" srcset="">
-    <p>Introducing Conversational learning ipsum dolar.</p>
+    <p>Introducing Conversational learning ipsum dolar</p>
     <span class="card-date">20 Oct 2022</span>
     <span class="dot">&#183;</span>
     <span class="card-timestamp">5 min read</span>

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.html
@@ -1,4 +1,4 @@
-<h1>Related Articles</h1>
+<h1>Related articles</h1>
 <div class="container">
   <div class="card">
     <img src="https://res.cloudinary.com/db15gy9h6/image/upload/v1678350142/Screenshot_from_2023-03-09_11-19-16_r7nfrz.png" alt="" srcset="">

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.scss
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.scss
@@ -1,0 +1,51 @@
+h1{
+  text-align: center;
+  font-weight: var( --elewa-group-website-font-weight-title-medium);
+  font-family: var( --elewa-group-website-dmsans-regular);
+  padding-top: 40px;
+}
+
+.container{
+  display: flex;
+  gap: 2rem;
+  padding-left: 70px;
+  align-items: center;
+  justify-content: center;
+  height: 90vh;
+}
+
+.container img{
+  border-radius: 20px ;
+}
+
+.card
+{
+  display: block;
+}
+.info {
+  font-family: var(--elewa-group-website-dmsans-medium);
+  color: var( --elewa-group-website-color-primary);
+  font-size: var(--elewa-group-website-font-size-hero-title);
+  margin-top: 30px;
+}
+.date-info{
+  margin-top: 10px;
+  font-size: var(--elewa-group-website-font-size-hero-description-medium);
+}
+
+.card-date{
+  font-family: var(  --elewa-group-website-dmsans-regular);
+  color: var( --elewa-group-website-color-primary);
+  font-size: var(--elewa-group-website-font-size-hero-subheading-medium);
+}
+
+.card-timestamp{
+  font-family: var(  --elewa-group-website-dmsans-regular);
+  color: var( --elewa-group-website-color-primary);
+  font-size: var(--elewa-group-website-font-size-hero-subheading-medium);
+}
+
+.container p {
+  font-size: var(--elewa-group-website-font-size-elewa-text);
+  padding-top: 30px;
+}

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.scss
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.scss
@@ -1,21 +1,32 @@
-h1{
+h1 {
   text-align: center;
-  font-weight: var( --elewa-group-website-font-weight-title-medium);
-  font-family: var( --elewa-group-website-dmsans-regular);
-  padding-top: 40px;
+  font-weight: var(--elewa-group-website-font-weight-title-medium);
+  font-family: var(--elewa-group-website-dmsans-regular);
+  padding-top: 20px;
+  @media (min-width: 768px) {
+    padding-top: 40px;
+  }
 }
 
-.container{
+.container {
   display: flex;
-  gap: 2rem;
-  padding-left: 70px;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 90vh;
+  height: auto;
+  padding: 20px;
+  gap: 1px;
+  @media (min-width: 768px) {
+    flex-direction: row;
+    height: 90vh;
+    padding: 0 70px;
+    gap: 2rem;
+  }
 }
 
 .container img{
   border-radius: 20px ;
+  max-width: 100%;
 }
 
 .card
@@ -27,25 +38,42 @@ h1{
   color: var( --elewa-group-website-color-primary);
   font-size: var(--elewa-group-website-font-size-hero-title);
   margin-top: 30px;
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
 }
 .date-info{
   margin-top: 10px;
   font-size: var(--elewa-group-website-font-size-hero-description-medium);
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+  }
 }
 
 .card-date{
   font-family: var(  --elewa-group-website-dmsans-regular);
   color: var( --elewa-group-website-color-primary);
   font-size: var(--elewa-group-website-font-size-hero-subheading-medium);
+  @media (max-width: 768px) {
+    font-size: 1rem;
+  }
 }
 
 .card-timestamp{
   font-family: var(  --elewa-group-website-dmsans-regular);
   color: var( --elewa-group-website-color-primary);
   font-size: var(--elewa-group-website-font-size-hero-subheading-medium);
+  @media (max-width: 768px) {
+    font-size: 1rem;
+  }
 }
 
 .container p {
-  font-size: var(--elewa-group-website-font-size-elewa-text);
+  font-size: var(--elewa-group-website-font-size-elewa-text-medium);
   padding-top: 30px;
+  padding-bottom: 10px;
+  max-width: 80%;
+  @media (max-width: 768px) {
+    font-size: 1rem;
+  }
 }

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.spec.ts
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewsRelatedArticlesComponent } from './news-related-articles.component';
+
+describe('NewsRelatedArticlesComponent', () => {
+  let component: NewsRelatedArticlesComponent;
+  let fixture: ComponentFixture<NewsRelatedArticlesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NewsRelatedArticlesComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewsRelatedArticlesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.ts
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-news-related-articles',
+  templateUrl: './news-related-articles.component.html',
+  styleUrls: ['./news-related-articles.component.scss'],
+})
+export class NewsRelatedArticlesComponent {}

--- a/libs/pages/elewa/news/src/lib/pages-elewa-news.module.ts
+++ b/libs/pages/elewa/news/src/lib/pages-elewa-news.module.ts
@@ -3,9 +3,10 @@ import { CommonModule } from '@angular/common';
 import { NewsPageComponent } from './pages/news-page/news-page.component';
 import { LayoutModule } from '@elewa-group/elements/layout';
 import { NewsRoutingModule } from './news.routing';
+import { NewsRelatedArticlesComponent } from 'libs/pages/elewa/news-detail/src/lib/pages/news-related-articles/news-related-articles.component';
 
 @NgModule({
   imports: [CommonModule, NewsRoutingModule, LayoutModule],
-  declarations: [NewsPageComponent],
+  declarations: [NewsPageComponent, NewsRelatedArticlesComponent],
 })
 export class NewsPageModule {}

--- a/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
+++ b/libs/pages/elewa/news/src/lib/pages/news-page/news-page.component.html
@@ -5,4 +5,6 @@
           
         </div>
     </elewa-group-elewa-group-main-page>
+
+    <elewa-group-news-related-articles></elewa-group-news-related-articles>
 </div>


### PR DESCRIPTION
# Description

This PR closes issue #445 which allows a user to know which articles are related to what they are currently viewing.

To achieve this, we needed to:

```
- Add the component of the news-related article to the news page component to view for proper editing
- Make frequent commits to help in tracing back errors
- Make it visible on the page so users can notice it easily
```

 Fixes #445  ([Create News Detail Related articles section](https://github.com/italanta/elewa-group/issues/445) 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Screenshot (optional)
Bigscreen View
![Screenshot from 2023-03-10 10-49-35](https://user-images.githubusercontent.com/110034881/224257947-0967d222-4dcc-4f51-849c-8438e9229709.png)

Phone View
![Screenshot from 2023-03-10 10-41-36](https://user-images.githubusercontent.com/110034881/224258078-970647b5-350f-4ee8-a04b-66c25ec088fb.png)




# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration if necessary.
- [x] Checking for appearance in the browser
- [x] writing code with no errors

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
