### PR TITLE
News page another

### DIFF
--- a/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
+++ b/libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+export interface Article {image: string; timestamp: string; title: string; body: string; topic: string;};
 
 @Component({
   selector: 'elewa-group-elewa-group-article-list',

--- a/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.html
+++ b/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.html
@@ -1,0 +1,1 @@
+<p>elewa-news-section works!</p>

--- a/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.html
+++ b/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.html
@@ -1,1 +1,37 @@
-<p>elewa-news-section works!</p>
+<div id="elewa-group-elewa-news-section">
+    <h1>News & Stories</h1>
+    <div id="news-section-options">
+        <button class="{{activeTopic == 'all-news' ? 'active' : ''}}" (click)="makeActive('all-news')">All News</button>
+        <button class="{{activeTopic == 'elewa' ? 'active' : ''}}"  (click)="makeActive('elewa')">Elewa</button>
+        <button class="{{activeTopic == 'italanta' ? 'active' : ''}}"  (click)="makeActive('italanta')">iTalanta</button>
+        <button class="{{activeTopic == 'venture-labs' ? 'active' : ''}}"  (click)="makeActive('venture-labs')">VentureLabs</button>
+        <button class="{{activeTopic == 'press' ? 'active' : ''}}"  (click)="makeActive('press')">Press</button>
+    </div>
+    
+    <div [ngSwitch]="activeTopic">
+        <elewa-group-elewa-group-article-list 
+            *ngSwitchCase="'all-news'"
+            [articles]="articlelists">
+        </elewa-group-elewa-group-article-list>
+
+        <elewa-group-elewa-group-article-list 
+            *ngSwitchCase="'elewa'"
+            [articles]="getNews('elewa')">
+        </elewa-group-elewa-group-article-list>
+
+        <elewa-group-elewa-group-article-list 
+            *ngSwitchCase="'italanta'"
+            [articles]="getNews('italanta')">
+        </elewa-group-elewa-group-article-list>
+
+        <elewa-group-elewa-group-article-list 
+            *ngSwitchCase="'venture-labs'"
+            [articles]="getNews('venture-labs')">
+        </elewa-group-elewa-group-article-list>
+
+        <elewa-group-elewa-group-article-list 
+            *ngSwitchCase="'press'"
+            [articles]="getNews('press')">
+        </elewa-group-elewa-group-article-list>
+    </div>
+</div>

--- a/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.scss
+++ b/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.scss
@@ -1,0 +1,54 @@
+#elewa-group-elewa-news-section h1 {
+    font-family: var(--elewa-group-website-dmsans-medium);
+    padding-top: 4rem;
+    margin-bottom: 1rem;
+    margin-left: 80px;
+    margin-right: 80px;
+}
+
+#elewa-group-elewa-news-section #news-section-options {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-left: 80px;
+    margin-right: 80px;
+    overflow: hidden;
+}
+
+#elewa-group-elewa-news-section button {
+    outline: none;
+    border: 0.1rem solid black;
+    cursor: pointer;
+    padding-top: 0.3rem;
+    padding-bottom: 0.3rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    border-top-right-radius: 1rem;
+    border-top-left-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+    border-bottom-left-radius: 1rem;
+    white-space: nowrap;
+}
+
+#elewa-group-elewa-news-section button:hover {
+    color: white;
+    background-color: black;
+}
+
+#elewa-group-elewa-news-section button.active {
+    color: white;
+    background-color: black;
+}
+
+@media (max-width: 767px) {
+    #elewa-group-elewa-news-section h1 {
+        margin-left: 60px;
+        margin-right: 60px;
+    }
+    
+    #elewa-group-elewa-news-section #news-section-options {
+        margin-left: 60px;
+        margin-right: 60px;
+    }    
+}

--- a/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.spec.ts
+++ b/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaNewsSectionComponent } from './elewa-news-section.component';
+
+describe('ElewaNewsSectionComponent', () => {
+  let component: ElewaNewsSectionComponent;
+  let fixture: ComponentFixture<ElewaNewsSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaNewsSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaNewsSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.ts
+++ b/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-elewa-news-section',
+  templateUrl: './elewa-news-section.component.html',
+  styleUrls: ['./elewa-news-section.component.scss'],
+})
+export class ElewaNewsSectionComponent {}

--- a/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.ts
+++ b/libs/pages/elewa/news/src/lib/components/elewa-news-section/elewa-news-section.component.ts
@@ -1,8 +1,48 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { Article } from 'libs/features/components/ui-lists/src/lib/elewa-group-article-list/elewa-group-article-list.component';
 
 @Component({
   selector: 'elewa-group-elewa-news-section',
   templateUrl: './elewa-news-section.component.html',
   styleUrls: ['./elewa-news-section.component.scss'],
 })
-export class ElewaNewsSectionComponent {}
+export class ElewaNewsSectionComponent {
+  @Input() articlelists = [
+      {image: 'https://thumbs.dreamstime.com/b/four-cute-cats-20650677.jpg', timestamp: '11:30', title: `And I'm grinding until I am tired`, body: '', topic: 'elewa'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '11:30', title: `This is Awesome`, body: '', topic: 'italanta'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcREzDhHtir8_-QwnyJ8633wNM1bEOEtPodDeg&usqp=CAU', timestamp: '12:13', title: `This is Awesome`, body: '', topic: 'venture-labs'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRTbOdzw8GXUNHXLQ6oWrs6ffc5aRZnLtZHhw&usqp=CAU', timestamp: '10:56', title: `This is Awesome`, body: '', topic: 'press'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTA0a7e50cvXyNQ1KcxZ2zpyX5DGlGVK13i6w&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'elewa'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQp7cqvRsYWpqVJP-sjK_VkFWqYBF_guiKzMA&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'italanta'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTtMBs2IlGh-6A0MUjuvzlEcgCjHKZwEIe1Jf-a4888atbcHQvsUfoTwxPjIQgw4whSOhE&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'venture-labs'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'press'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'elewa'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTA0a7e50cvXyNQ1KcxZ2zpyX5DGlGVK13i6w&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'italanta'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTA0a7e50cvXyNQ1KcxZ2zpyX5DGlGVK13i6w&usqp=CAU', timestamp: '11:30', title: `This is Awesome`, body: '', topic: 'elewa'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '11:30', title: `This is Awesome`, body: '', topic: 'italanta'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTA0a7e50cvXyNQ1KcxZ2zpyX5DGlGVK13i6w&usqp=CAU', timestamp: '12:13', title: `This is Awesome`, body: '', topic: 'venture-labs'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTtMBs2IlGh-6A0MUjuvzlEcgCjHKZwEIe1Jf-a4888atbcHQvsUfoTwxPjIQgw4whSOhE&usqp=CAU', timestamp: '10:56', title: `This is Awesome`, body: '', topic: 'press'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'elewa'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTA0a7e50cvXyNQ1KcxZ2zpyX5DGlGVK13i6w&usqp=CAU', timestamp: '08:43', title: `And the light`, body: '', topic: 'italanta'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTtMBs2IlGh-6A0MUjuvzlEcgCjHKZwEIe1Jf-a4888atbcHQvsUfoTwxPjIQgw4whSOhE&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'venture-labs'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'press'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-N12wOMy-iPxJQOg_D_FHK5Qsu1NoHVNBHA&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'elewa'},
+      {image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTtMBs2IlGh-6A0MUjuvzlEcgCjHKZwEIe1Jf-a4888atbcHQvsUfoTwxPjIQgw4whSOhE&usqp=CAU', timestamp: '08:43', title: `This is Awesome`, body: '', topic: 'italanta'}
+    ]
+
+  @Input() activeTopic = 'all-news'
+
+  makeActive(topic: string){
+    this.activeTopic = topic
+  }
+
+  getNews(activeTopic: string) :Article[] {
+    if(activeTopic == 'all-news'){
+      return this.articlelists;
+    }
+
+    return this.articlelists.filter(article => {
+      return article.topic == activeTopic;
+    })
+  }
+}

--- a/libs/pages/elewa/news/src/lib/pages-elewa-news.module.ts
+++ b/libs/pages/elewa/news/src/lib/pages-elewa-news.module.ts
@@ -4,9 +4,10 @@ import { NewsPageComponent } from './pages/news-page/news-page.component';
 import { LayoutModule } from '@elewa-group/elements/layout';
 import { NewsRoutingModule } from './news.routing';
 import { UiListsModule } from '@elewa-group/features/components/ui-lists';
+import { ElewaNewsSectionComponent } from './components/elewa-news-section/elewa-news-section.component';
 
 @NgModule({
-  imports: [CommonModule, NewsRoutingModule, LayoutModule,UiListsModule],
-  declarations: [NewsPageComponent],
+  imports: [CommonModule, NewsRoutingModule, LayoutModule, UiListsModule],
+  declarations: [NewsPageComponent, ElewaNewsSectionComponent],
 })
 export class NewsPageModule {}


### PR DESCRIPTION
Created a tabbed news section which filters the news list when a user clicks on a tab.

To achieve this, we did the following;
-Step 1: Created the elewa-news-section component inside the components directory by using the command;
nx g c elewa-news-section

-Step 2: Modify the contents of three files;
• elewa-news-section.component.html
•elewa-news-section.component.ts
• elewa-news-section.scss
These files were created when we created the elewa-news-section component

-Step 3: Commented out stuff on the file app.component.html and added a selector to our component to test our work

Fixes # (issue #443)
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)

![Screenshot from 2023-03-10 11-24-51](https://user-images.githubusercontent.com/81687679/224263547-d39c8e5c-63e3-4587-b893-4422842cdd2f.png)

![Screenshot from 2023-03-10 11-25-12](https://user-images.githubusercontent.com/81687679/224263589-a4892a29-cc74-4fd7-b3da-5f28659e88e2.png)



# How Has This Been Tested?
Step 1: Commented out everything in the news-page.component.html and added a elewa-group-elewa-news-section selector for our component
Step 2: Ran nx serve elewa-group-website
Step 3: Tested how the site would look on different devices using chrome developer tools.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
