### PR TITLE
445/news detail related articles

### DIFF
--- a/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.html
@@ -1,0 +1,1 @@
+<p>news-related-articles works!</p>

--- a/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.html
@@ -1,1 +1,29 @@
-<p>news-related-articles works!</p>
+<div class="related-artciles">
+    <div class="articleheader">
+        <h1>Related  Articles</h1>
+    </div>
+    <div class="article-list">
+        <div class="article">
+            <img src="https://media.gettyimages.com/id/1017628288/photo/happy-african-family-together-using-laptop.jpg?s=612x612&w=0&k=20&c=RWPnLiMhvcbKvzBX4fW7D2p8R26Iv_k0hDaxu_GEA6A=" alt="">
+            <div class="info">
+                <p class="title">Introducing conversational learning ipsum dollar</p>
+                <span class="timestamp">22 Oct 2022 <span class="dot">·</span> <p class="read-time">5 min read </p></span>
+            </div>
+        </div>
+        <div class="article">
+            <img src="https://media.gettyimages.com/id/1017628288/photo/happy-african-family-together-using-laptop.jpg?s=612x612&w=0&k=20&c=RWPnLiMhvcbKvzBX4fW7D2p8R26Iv_k0hDaxu_GEA6A=" alt="">
+            <div class="info">
+                <p class="title">Introducing conversational learning ipsum dollar</p>
+                <span class="timestamp">22 Oct 2022 <span class="dot">·</span> <p class="read-time">5 min read </p></span>
+            </div>
+        </div>
+        <div class="article">
+            <img src="https://media.gettyimages.com/id/1017628288/photo/happy-african-family-together-using-laptop.jpg?s=612x612&w=0&k=20&c=RWPnLiMhvcbKvzBX4fW7D2p8R26Iv_k0hDaxu_GEA6A=" alt="">
+            <div class="info">
+                <p class="title">Introducing conversational learning ipsum dollar</p>
+                <span class="timestamp">22 Oct 2022 <span class="dot">·</span> <p class="read-time">5 min read </p></span>
+            </div>
+        </div>
+
+    </div>
+</div>

--- a/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.scss
+++ b/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.scss
@@ -1,0 +1,81 @@
+.articleheader {
+    text-align: center;
+    margin: 0 auto;
+    padding: 20px;
+  }
+
+  .article-list {
+    position: relative;
+    display: flex;
+    overflow-x: hidden;
+    justify-content: center;
+    margin: 40px 0;
+    gap: 10px; /* added gap property */
+  }
+
+  .article {
+    display: flex;
+    flex-direction: column;
+    scroll-snap-align: center;
+    width: 300px;
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 0 10;
+  }
+
+  .article img {
+    width: 300px;
+    height: 350px;
+    object-fit: cover;
+    border-radius: 10px;
+  }
+
+  .article .info {
+    font-family: var(--elewa-group-website-dmsans-regular);
+    padding: 10px;
+    background-color: white;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    border-radius: 10px;
+  }
+
+  .article .info .title {
+    margin-top: 10px;
+    font-family: var(--elewa-group-website-dmsans-regular);
+    flex-grow: 1;
+  }
+
+  .article .info .timestamp {
+    font-family: var(--elewa-group-website-dmsans-regular);
+    flex-direction: row;
+    font-size: 0.8rem;
+    color: black;
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+  }
+
+  .timestamp .dot {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 0 0.5rem;
+  }
+
+  .article .info .read-time {
+    font-family: var(--elewa-group-website-dmsans-regular);
+    font-size: 0.6rem;
+    color: black;
+    display: flex;
+  }
+
+  @media screen and (max-width: 768px) {
+    .article-list {
+      flex-wrap: wrap;
+      margin: 0 10px;
+    }
+    .article {
+      margin: 10px;
+    }
+  }

--- a/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.spec.ts
+++ b/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewsRelatedArticlesComponent } from './news-related-articles.component';
+
+describe('NewsRelatedArticlesComponent', () => {
+  let component: NewsRelatedArticlesComponent;
+  let fixture: ComponentFixture<NewsRelatedArticlesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NewsRelatedArticlesComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewsRelatedArticlesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.ts
+++ b/libs/pages/elewa/news-detail/src/lib/components/news-related-articles/news-related-articles.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-group-news-related-articles',
+  templateUrl: './news-related-articles.component.html',
+  styleUrls: ['./news-related-articles.component.scss'],
+})
+export class NewsRelatedArticlesComponent {}

--- a/libs/pages/elewa/news-detail/src/lib/pages-elewa-news-detail.module.ts
+++ b/libs/pages/elewa/news-detail/src/lib/pages-elewa-news-detail.module.ts
@@ -4,9 +4,10 @@ import { CommonModule } from '@angular/common';
 import { LayoutModule } from '@elewa-group/elements/layout';
 
 import { NewsDetailPageComponent } from './pages/news-detail-page/news-detail-page.component';
+import { NewsRelatedArticlesComponent } from './components/news-related-articles/news-related-articles.component';
 
 @NgModule({
   imports: [CommonModule, LayoutModule],
-  declarations: [NewsDetailPageComponent],
+  declarations: [NewsDetailPageComponent, NewsRelatedArticlesComponent],
 })
 export class ElewaNewsDetailModule {}

--- a/libs/pages/elewa/news-detail/src/lib/pages/news-detail-page/news-detail-page.component.html
+++ b/libs/pages/elewa/news-detail/src/lib/pages/news-detail-page/news-detail-page.component.html
@@ -1,9 +1,9 @@
 <div>
   <elewa-group-elewa-group-main-page>
     <div mainPage class="home-page">
-      
-    </div> 
+       <elewa-group-news-related-articles></elewa-group-news-related-articles>
+    </div>
   </elewa-group-elewa-group-main-page>
-  
+
 </div>
 


### PR DESCRIPTION
# Description

 This pull request is to let users know which articles are related to what they currently viewing

To achieve this, we needed to:

```
- Create the news related Component
- Add html for the component
- Style component
```

Fixes #445

## Type of change
 
- [ ] New feature (non-breaking change which adds functionality)
 

# Screenshot (optional)
## Desktop view
![desktop relTED  ](https://user-images.githubusercontent.com/108519631/224280778-62282718-60d3-4a7a-a05a-63db9659c4b2.png)
## Mobile view
![mobile view](https://user-images.githubusercontent.com/108519631/224280887-50333945-3fc7-406f-b9b0-8eaabd94d0d8.png)

# How Has This Been Tested?
 Used Chrome Dev tools to check for responsiveness

 

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
